### PR TITLE
Fix WebSocket routing for Vertex preview containers

### DIFF
--- a/server-config/preview.sh
+++ b/server-config/preview.sh
@@ -171,6 +171,12 @@ ${slug}.${domain} {
     handle /api/* {
         reverse_proxy ${container_ip}:4000
     }
+    handle /websocket {
+        reverse_proxy ${container_ip}:4000
+    }
+    handle /longpoll/* {
+        reverse_proxy ${container_ip}:4000
+    }
     handle /admin/* {
         reverse_proxy ${container_ip}:3000
     }


### PR DESCRIPTION
## Summary
- Phoenix mounts its socket at `"/"`, so the JS client connects to `/websocket` for upgrades and `/longpoll` for the fallback transport
- Neither path matched the existing `/api/*` or `/admin/*` Caddy handles, causing them to fall through to the static file server on port 3001 instead of reaching the Phoenix backend on port 4000
- Adds explicit Caddy `handle` blocks for `/websocket` and `/longpoll/*` routing them to port 4000

## Test plan
- [ ] Deploy a Vertex preview and verify WebSocket connections succeed (check browser devtools Network tab for the `/websocket` upgrade)
- [ ] Verify `/api/*` routes still reach Phoenix backend
- [ ] Verify admin and foods frontends still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)