### PR TITLE
Add restolia landing page to vertex previews and fix admin routing

### DIFF
--- a/server-config/preview-webhook/src/index.ts
+++ b/server-config/preview-webhook/src/index.ts
@@ -89,7 +89,12 @@ async function main(): Promise<void> {
           case "reopened": {
             await createPreview(repo, branch, slug, type);
             const url = `https://${slug}.${config.previewDomain}`;
-            await addPreviewLinkToPR(repo, prNumber, url, config.githubToken);
+            if (type === "vertex") {
+              const landingUrl = `https://landing-${slug}.${config.previewDomain}`;
+              await addPreviewLinkToPR(repo, prNumber, url, config.githubToken, landingUrl);
+            } else {
+              await addPreviewLinkToPR(repo, prNumber, url, config.githubToken);
+            }
             break;
           }
           case "synchronize": {

--- a/server-config/preview-webhook/src/preview.ts
+++ b/server-config/preview-webhook/src/preview.ts
@@ -44,7 +44,8 @@ export async function addPreviewLinkToPR(
   repo: string,
   prNumber: number,
   previewUrl: string,
-  token: string
+  token: string,
+  landingUrl?: string
 ): Promise<void> {
   console.log(`[preview] Adding preview link to ${repo}#${prNumber}`);
   try {
@@ -70,6 +71,9 @@ export async function addPreviewLinkToPR(
 
     // Append preview link
     body += `\n\n${PREVIEW_LINK_MARKER}\n---\n**Preview:** ${previewUrl}`;
+    if (landingUrl) {
+      body += `\n**Landing:** ${landingUrl}`;
+    }
 
     // Update PR
     const patchRes = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`, {

--- a/server-config/preview.sh
+++ b/server-config/preview.sh
@@ -157,7 +157,7 @@ EOF
 
 remove_caddy_route() {
     local slug="$1"
-    rm -f "${CADDY_DIR}/${slug}.caddy"
+    rm -f "${CADDY_DIR}/${slug}.caddy" "${CADDY_DIR}/${slug}-landing.caddy"
     systemctl reload caddy
 }
 
@@ -171,10 +171,17 @@ ${slug}.${domain} {
     handle /api/* {
         reverse_proxy ${container_ip}:4000
     }
-    handle /admin/* {
+    redir /admin /admin/
+    handle_path /admin/* {
         reverse_proxy ${container_ip}:3000
     }
     reverse_proxy ${container_ip}:3001
+}
+EOF
+
+    cat > "${CADDY_DIR}/${slug}-landing.caddy" <<EOF
+landing-${slug}.${domain} {
+    reverse_proxy ${container_ip}:3002
 }
 EOF
 
@@ -395,7 +402,7 @@ EOF
 
     # Kick off setup and services (type-specific)
     if [[ "$type" == "vertex" ]]; then
-        nixos-container run "$slug" -- systemctl start setup-vertex vertex-backend vertex-frontend-admin vertex-frontend-foods &
+        nixos-container run "$slug" -- systemctl start setup-vertex vertex-backend vertex-frontend-admin vertex-frontend-foods vertex-frontend-landing &
         write_vertex_caddy_route "$slug" "$local_ip"
     else
         nixos-container run "$slug" -- systemctl start setup-preview preview-app &
@@ -405,6 +412,9 @@ EOF
     success "Preview '$slug' created and starting."
     echo ""
     echo -e "  ${BOLD}URL:${NC}           ${preview_url}"
+    if [[ "$type" == "vertex" ]]; then
+        echo -e "  ${BOLD}Landing:${NC}       https://landing-${slug}.${domain}"
+    fi
     echo -e "  ${BOLD}Type:${NC}          $type"
     echo -e "  ${BOLD}Container IP:${NC}  $local_ip"
     echo -e "  ${BOLD}Repo:${NC}          $repo"
@@ -469,7 +479,7 @@ cmd_update() {
 
     if [[ "$type" == "vertex" ]]; then
         nixos-container run "$slug" -- bash -c \
-            "systemctl restart setup-vertex && systemctl restart vertex-backend vertex-frontend-admin vertex-frontend-foods"
+            "systemctl restart setup-vertex && systemctl restart vertex-backend vertex-frontend-admin vertex-frontend-foods vertex-frontend-landing"
     else
         nixos-container run "$slug" -- bash -c \
             "systemctl restart setup-preview && systemctl restart preview-app"
@@ -537,7 +547,7 @@ cmd_logs() {
 
     local -a units
     if [[ "$type" == "vertex" ]]; then
-        units=(-u setup-vertex -u vertex-backend -u vertex-frontend-admin -u vertex-frontend-foods)
+        units=(-u setup-vertex -u vertex-backend -u vertex-frontend-admin -u vertex-frontend-foods -u vertex-frontend-landing)
     else
         units=(-u setup-preview -u preview-app)
     fi
@@ -561,7 +571,7 @@ cmd_help() {
     echo ""
     echo -e "${BOLD}Preview types:${NC}"
     echo "  node     Node.js app (npm ci, npm build, npm start on port 3000)"
-    echo "  vertex   Elixir/Phoenix + React SPA monorepo (backend:4000, frontends:3000/3001)"
+    echo "  vertex   Elixir/Phoenix + React SPA monorepo (backend:4000, frontends:3000/3001, landing:3002)"
     echo ""
     echo -e "${BOLD}Examples:${NC}"
     echo "  preview build"

--- a/server-config/vertex-preview-config.nix
+++ b/server-config/vertex-preview-config.nix
@@ -26,8 +26,8 @@ in
   };
   networking.nameservers = [ "8.8.8.8" "1.1.1.1" ];
 
-  # Open ports: 3000 (admin frontend), 3001 (foods frontend), 4000 (Phoenix backend)
-  networking.firewall.allowedTCPPorts = [ 3000 3001 4000 ];
+  # Open ports: 3000 (admin frontend), 3001 (foods frontend), 3002 (landing page), 4000 (Phoenix backend)
+  networking.firewall.allowedTCPPorts = [ 3000 3001 3002 4000 ];
 
   # PostgreSQL (runs inside the container for isolation — no shared host connections)
   services.postgresql = {
@@ -56,7 +56,7 @@ in
     description = "Setup Vertex preview (clone, build, migrate)";
     after = [ "systemd-resolved.service" "redis-vertex.service" "postgresql.service" ];
     wants = [ "systemd-resolved.service" "redis-vertex.service" "postgresql.service" ];
-    before = [ "vertex-backend.service" "vertex-frontend-admin.service" "vertex-frontend-foods.service" ];
+    before = [ "vertex-backend.service" "vertex-frontend-admin.service" "vertex-frontend-foods.service" "vertex-frontend-landing.service" ];
     path = [
       pkgs.bash pkgs.coreutils pkgs.findutils pkgs.gnugrep pkgs.gnused
       pkgs.git erlang elixir pkgs.nodejs_22 pkgs.pnpm pkgs.gcc pkgs.gnumake
@@ -140,6 +140,14 @@ in
 
       echo "Frontend build complete."
 
+      # ── Landing page build ──────────────────────────────────────────────
+      echo "Building landing page..."
+      cd "$APP_DIR/landings"
+      ${pkgs.pnpm}/bin/pnpm install
+      cd "$APP_DIR/landings/restolia"
+      ${pkgs.pnpm}/bin/pnpm build
+      echo "Landing page build complete."
+
       # ── Database migrations ────────────────────────────────────────────
       echo "Running database migrations..."
       cd "$APP_DIR"
@@ -199,6 +207,21 @@ in
       User = "preview";
       WorkingDirectory = "/home/preview/app/frontend/apps/platform";
       ExecStart = "${pkgs.nodejs_22}/bin/npx serve -s dist-foods -l 3001";
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+  };
+
+  systemd.services.vertex-frontend-landing = {
+    description = "Vertex landing page (port 3002)";
+    after = [ "setup-vertex.service" ];
+    requires = [ "setup-vertex.service" ];
+    path = [ pkgs.bash pkgs.coreutils pkgs.nodejs_22 ];
+    serviceConfig = {
+      Type = "simple";
+      User = "preview";
+      WorkingDirectory = "/home/preview/app/landings/restolia";
+      ExecStart = "${pkgs.nodejs_22}/bin/npx serve -s dist -l 3002";
       Restart = "on-failure";
       RestartSec = 5;
     };


### PR DESCRIPTION
## Summary
- Build and serve the restolia landing page (`landings/restolia/`) on port 3002 inside vertex preview containers, exposed at `landing-<slug>.preview.hipermegared.link`
- Fix admin frontend routing: switch Caddy from `handle /admin/*` to `handle_path /admin/*` so the `/admin` prefix is stripped before proxying to `serve`, allowing static assets to resolve correctly
- Add landing URL to GitHub PR descriptions for vertex repos via the webhook

## Test plan
- [ ] Deploy `preview.sh` and `vertex-preview-config.nix` to the server, rebuild NixOS and vertex closure
- [ ] Create a vertex preview and verify the landing page loads at `landing-<slug>.preview.hipermegared.link`
- [ ] Verify `/admin/` loads correctly with JS/CSS assets
- [ ] Verify `preview logs` includes `vertex-frontend-landing` output
- [ ] Verify `preview destroy` cleans up both Caddy files (`<slug>.caddy` and `<slug>-landing.caddy`)