### PR TITLE
Fix force-rebuild file permission in preview update

### DIFF
--- a/server-config/preview.sh
+++ b/server-config/preview.sh
@@ -538,7 +538,7 @@ cmd_update() {
     fi
 
     # Signal the setup service to do a full rebuild (not skip due to existing build)
-    nixos-container run "$slug" -- touch /tmp/force-rebuild
+    nixos-container run "$slug" -- su -s /bin/sh preview -c "touch /tmp/force-rebuild"
 
     if [[ "$type" == "vertex" ]]; then
         nixos-container run "$slug" -- bash -c \


### PR DESCRIPTION
## Summary
- `preview update` created `/tmp/force-rebuild` as root via `nixos-container run`, but `setup-vertex` runs as the `preview` user and couldn't delete it (`set -e` caused immediate exit)
- This cascaded to all dependent services (backend + 3 frontends) failing with `dependency` errors
- The bug triggered on every `synchronize` webhook (new push to a PR with an active preview)

## Fix
Create the marker file as the `preview` user instead of root:
```bash
# Before
nixos-container run "$slug" -- touch /tmp/force-rebuild

# After
nixos-container run "$slug" -- su -s /bin/sh preview -c "touch /tmp/force-rebuild"
```

## Test plan
- [x] Hotfixed on vertex-preview-00 and verified all 21 containers are back up
- [ ] Push a new commit to a PR with an active vertex preview, confirm the update succeeds