### PR TITLE
Add task reopen and follow-up conversation context

### DIFF
--- a/dashboard/backend/src/main.rs
+++ b/dashboard/backend/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/tasks/{id}/subtasks", get(tasks::get_subtasks))
         .route("/tasks/{id}/messages", get(tasks::list_messages))
         .route("/tasks/{id}/messages", post(tasks::send_message))
+        .route("/tasks/{id}/reopen", post(tasks::reopen_task))
         // Uploads
         .route("/uploads", post(tasks::upload_image))
         // Classify

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -455,6 +455,15 @@ async fn follow_up_loop(
 ) -> Result<FollowUpOutcome, AppError> {
     let mut last_seen_id: i64 = 0;
 
+    // Fetch the original task prompt for context
+    let original_prompt = sqlx::query_scalar::<_, String>("SELECT prompt FROM tasks WHERE id = ?")
+        .bind(task_id)
+        .fetch_one(db)
+        .await?;
+
+    // Track conversation history for context
+    let mut conversation_history: Vec<String> = Vec::new();
+
     update_task_status(db, task_id, "awaiting_followup", None).await?;
     let _ = tx.send("[STATUS] Waiting for follow-up messages (click 'Mark Done' to finish)...".to_string());
 
@@ -489,11 +498,17 @@ async fn follow_up_loop(
                 config, agent_name, msg.image_url.as_deref(), &msg.content, tx,
             ).await?;
 
+            // Build context-aware prompt with original task + conversation history
+            let context_prompt = build_followup_prompt(&original_prompt, &conversation_history, &effective_content);
+
+            // Add this message to history for future follow-ups
+            conversation_history.push(format!("{}: {}", msg.sender, msg.content));
+
             // Re-invoke Claude with the follow-up message
             let _ = tx.send(format!("[FOLLOWUP] Running Claude with follow-up from {}...", msg.sender));
             update_task_status(db, task_id, "running_claude", None).await?;
 
-            run_claude_streaming(agent_name, &effective_content, tx.clone()).await?;
+            run_claude_streaming(agent_name, &context_prompt, tx.clone()).await?;
             let _ = commit_changes_in_agent(agent_name, &msg.content, tx.clone()).await?;
 
             // Push and update preview
@@ -503,6 +518,22 @@ async fn follow_up_loop(
             let _ = tx.send("[STATUS] Waiting for more follow-up messages...".to_string());
         }
     }
+}
+
+/// Build a follow-up prompt that includes the original task context and conversation history.
+fn build_followup_prompt(original_prompt: &str, history: &[String], new_message: &str) -> String {
+    let mut prompt = format!("ORIGINAL TASK:\n{original_prompt}\n\n");
+
+    if !history.is_empty() {
+        prompt.push_str("PREVIOUS FOLLOW-UP MESSAGES (already addressed):\n");
+        for msg in history {
+            prompt.push_str(&format!("- {msg}\n"));
+        }
+        prompt.push('\n');
+    }
+
+    prompt.push_str(&format!("NEW FOLLOW-UP (address this now):\n{new_message}"));
+    prompt
 }
 
 async fn push_and_preview(
@@ -812,6 +843,119 @@ async fn update_task_field(
         .bind(task_id)
         .execute(db)
         .await?;
+    Ok(())
+}
+
+pub async fn reopen_task(
+    _user: AuthUser,
+    State(state): State<crate::AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Task>, AppError> {
+    let task = sqlx::query_as::<_, Task>("SELECT * FROM tasks WHERE id = ?")
+        .bind(&id)
+        .fetch_optional(&state.db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Task not found".into()))?;
+
+    if task.status != "completed" && task.status != "failed" {
+        return Err(AppError::BadRequest(format!(
+            "Can only reopen completed or failed tasks, current status: {}",
+            task.status
+        )));
+    }
+
+    let branch_name = task.branch_name.as_deref().ok_or_else(|| {
+        AppError::BadRequest("Task has no branch — cannot reopen".into())
+    })?;
+
+    let short_id = &id[..6];
+
+    // Reset status and error
+    update_task_status(&state.db, &id, "creating_agent", None).await?;
+
+    // Create broadcast channel
+    let (tx, _) = broadcast::channel(1024);
+    state.task_channels.insert(id.clone(), tx.clone());
+
+    // Spawn background pipeline
+    let config = state.config.clone();
+    let db = state.db.clone();
+    let task_id = id.clone();
+    let short = short_id.to_string();
+    let repo = task.repo.clone();
+    let branch = branch_name.to_string();
+    let has_preview = task.preview_url.is_some();
+    let channels = state.task_channels.clone();
+
+    tokio::spawn(async move {
+        let agent_name = format!("a-{short}");
+        let result = run_reopen_pipeline(
+            &config, &db, &task_id, &short, &repo, &branch, has_preview, tx.clone(),
+        )
+        .await;
+
+        if let Err(e) = &result {
+            let _ = update_task_status(&db, &task_id, "failed", Some(&e.to_string())).await;
+            let _ = tx.send(format!("[ERROR] Reopen failed: {e}"));
+            let _ = shell::destroy_agent(&config, &agent_name).await;
+        }
+
+        let channels2 = channels;
+        let tid = task_id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            channels2.remove(&tid);
+        });
+    });
+
+    let task = sqlx::query_as::<_, Task>("SELECT * FROM tasks WHERE id = ?")
+        .bind(&id)
+        .fetch_one(&state.db)
+        .await?;
+    Ok(Json(task))
+}
+
+async fn run_reopen_pipeline(
+    config: &Config,
+    db: &SqlitePool,
+    task_id: &str,
+    short_id: &str,
+    repo: &str,
+    branch_name: &str,
+    had_preview: bool,
+    tx: broadcast::Sender<String>,
+) -> Result<(), AppError> {
+    let agent_name = format!("a-{short_id}");
+
+    // Step 1: Create agent container
+    log_and_send(db, task_id, &tx, &format!("[STEP] Creating agent container '{agent_name}' (reopen)..."));
+    shell::create_agent(config, &agent_name).await?;
+    update_task_field(db, task_id, "agent_name", &agent_name).await?;
+
+    // Step 2: Clone repo and checkout existing branch
+    update_task_status(db, task_id, "cloning", None).await?;
+    log_and_send(db, task_id, &tx, &format!("[STEP] Cloning {repo} and checking out existing branch {branch_name}..."));
+
+    let token = get_github_token().await?;
+    let clone_url = format!("https://x-access-token:{token}@github.com/{repo}.git");
+
+    let clone_cmd = format!(
+        "cd /home/agent && git clone '{clone_url}' repo && \
+         cd repo && git checkout '{branch_name}'"
+    );
+    shell::agent_exec(&agent_name, &clone_cmd, tx.clone()).await?;
+
+    // Step 3: Go straight into follow-up loop
+    let mut preview_created = had_preview;
+    follow_up_loop(config, db, task_id, short_id, &agent_name, repo, branch_name, &mut preview_created, &tx).await?;
+
+    // Step 4: Destroy agent
+    log_and_send(db, task_id, &tx, "[STEP] Destroying agent container...");
+    let _ = shell::destroy_agent(config, &agent_name).await;
+
+    update_task_status(db, task_id, "completed", None).await?;
+    log_and_send(db, task_id, &tx, "[DONE] Task completed.");
+
     Ok(())
 }
 

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -117,6 +117,8 @@ export const sendTaskMessage = (id: string, content: string, image_urls?: string
     method: 'POST',
     body: JSON.stringify({ content, image_urls }),
   });
+export const reopenTask = (id: string) =>
+  apiFetch<Task>(`/api/tasks/${id}/reopen`, { method: 'POST' });
 
 /** Parse image_url JSON column (stored as JSON array string) into an array of URLs. */
 export function parseImageUrls(raw: string | null | undefined): string[] {

--- a/dashboard/frontend/src/pages/TaskDetail.tsx
+++ b/dashboard/frontend/src/pages/TaskDetail.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { ChevronLeft, RefreshCw, ExternalLink } from 'lucide-react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { ChevronLeft, RefreshCw, ExternalLink, RotateCcw } from 'lucide-react';
 import LogViewer from '@/components/LogViewer';
 import TaskChat from '@/components/TaskChat';
-import { getTask, listSubtasks, getMe, parseImageUrls } from '@/lib/api';
+import { getTask, listSubtasks, getMe, parseImageUrls, reopenTask } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -54,7 +54,16 @@ export default function TaskDetail() {
 
   const onConnectionChange = useCallback((c: boolean) => setConnected(c), []);
 
+  const queryClient = useQueryClient();
+  const reopenMutation = useMutation({
+    mutationFn: () => reopenTask(id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['task', id] });
+    },
+  });
+
   const showChat = task && CHAT_STATUSES.includes(task.status);
+  const canReopen = task && (task.status === 'completed' || task.status === 'failed');
 
   return (
     <div>
@@ -68,6 +77,17 @@ export default function TaskDetail() {
         <Badge variant={connected ? 'default' : 'outline'}>
           {connected ? 'Live' : 'Disconnected'}
         </Badge>
+        {canReopen && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => reopenMutation.mutate()}
+            disabled={reopenMutation.isPending}
+          >
+            <RotateCcw className="size-4 mr-1" />
+            {reopenMutation.isPending ? 'Reopening...' : 'Reopen'}
+          </Button>
+        )}
       </div>
 
       {task && (


### PR DESCRIPTION
## Summary
- **Reopen tasks**: Completed/failed tasks get a "Reopen" button that spins up a new agent, clones the repo, checks out the existing branch, and enters the follow-up loop for further iteration
- **Follow-up context**: Each follow-up message now includes the original task prompt and all previous follow-up messages, so Claude has full context instead of seeing each follow-up in isolation

## Problem
1. Once a task was completed or failed, there was no way to continue iterating on it without creating a new task from scratch
2. Follow-up messages were sent to Claude with zero context — sending "Still broken" meant Claude literally only saw those two words with no knowledge of the original task or what it had already tried

## Test plan
- [ ] Complete a task, verify "Reopen" button appears
- [ ] Click Reopen, verify new agent is created and task enters follow-up loop
- [ ] Send a follow-up message, verify Claude receives the original prompt + conversation history
- [ ] Send multiple follow-ups, verify each includes all prior messages