### PR TITLE
Remove all hardcoded values

### DIFF
--- a/dashboard/DEPLOY.md
+++ b/dashboard/DEPLOY.md
@@ -11,7 +11,7 @@ The dashboard is a web application for managing NixOS preview containers and run
                                   |
                            Caddy (TLS termination)
                           /                \
-            dashboard.hipermegared.link    *.hipermegared.link
+            dashboard.yourdomain.com    *.yourdomain.com
                      |                          |
               Dashboard (port 3200)      Preview containers
               - Rust/Axum backend        - Node.js or Vertex (Elixir)
@@ -63,7 +63,7 @@ Key points:
 
 ### 1. Cloudflare DNS
 
-You need three DNS records for your domain (e.g., `hipermegared.link`):
+You need three DNS records for your domain (e.g., `yourdomain.com`):
 
 | Type | Name | Content | Proxy |
 |------|------|---------|-------|
@@ -71,12 +71,12 @@ You need three DNS records for your domain (e.g., `hipermegared.link`):
 | A | `*` | `<server-ip>` | Proxied |
 | A | `@` | `<server-ip>` | Proxied |
 
-The wildcard record is needed for preview subdomains like `t-abc123.hipermegared.link`.
+The wildcard record is needed for preview subdomains like `t-abc123.yourdomain.com`.
 
 **Cloudflare Origin CA Certificate:**
 
 1. Go to SSL/TLS > Origin Server > Create Certificate
-2. Generate a certificate covering `*.hipermegared.link` and `hipermegared.link`
+2. Generate a certificate covering `*.yourdomain.com` and `yourdomain.com`
 3. Save the certificate as `cloudflare-origin.pem` and the private key as `cloudflare-origin-key.pem`
 4. These will be placed on the server at `/var/secrets/`
 
@@ -112,7 +112,7 @@ After creating:
 5. Authorized redirect URIs: `https://dashboard.yourdomain.com/api/auth/callback`
 6. Note the **Client ID** and **Client Secret**
 
-If you want to restrict login to a specific domain (e.g., `@lambdaclass.com`), the dashboard enforces this via the `ALLOWED_DOMAIN` environment variable.
+If you want to restrict login to a specific domain (e.g., `@yourdomain.com`), the dashboard enforces this via the `ALLOWED_DOMAIN` environment variable.
 
 ### 4. Claude Code Authentication
 
@@ -262,7 +262,19 @@ The `configuration.nix` file includes:
 - **PostgreSQL** — shared database for preview containers
 - **`agent` and `preview` CLI tools** — wrapped shell scripts for container management
 
-**Important:** `configuration.nix` in this repo has placeholder values (`YOUR.SERVER.IP.HERE`, `ssh-ed25519 AAAA... your-key-here`, etc.). The setup script substitutes these with real values. **Never scp the template directly to the server.**
+**Important:** Template files in this repo have placeholder values that must be substituted before use. **Never scp them directly to the server.** The `setup.sh` script handles substitution automatically. Placeholders:
+
+| File | Placeholder | Substituted with |
+|------|-------------|-----------------|
+| `configuration.nix` | `YOUR.SERVER.IP.HERE` | Server IP address |
+| `configuration.nix` | `YOUR.GATEWAY.IP.HERE` | Gateway IP address |
+| `configuration.nix` | `DISK_DEVICE_0`, `DISK_DEVICE_1` | Disk device paths |
+| `configuration.nix` | `INITRD_KERNEL_MODULES` | Initrd kernel modules |
+| `configuration.nix` | `dashboard.YOUR_DOMAIN` | Dashboard domain (e.g., `dashboard.yourdomain.com`) |
+| `configuration.nix` | `ssh-ed25519 AAAA... your-key-here` | Your SSH public key |
+| `agent-config.nix` | `YOUR_GIT_EMAIL` | Git commit email (must match GitHub account with signing key) |
+| `agent-config.nix` | `ssh-ed25519 AAAA... your-key-here` | Your SSH public key |
+| `agent-config.nix` | `ssh-ed25519 AAAA... root-key-here` | Server's root SSH public key |
 
 ### First-time Setup
 
@@ -313,8 +325,8 @@ Use the `deploy.sh` script from the repo root. It pushes your current branch, pu
 
 ### Notes
 
-- **Never scp `configuration.nix` directly** — the local copy has placeholder values. Either edit on the server or use `setup.sh` for a fresh install.
-- The deploy script skips `configuration.nix` automatically (it only copies the supporting `.nix` files and scripts).
+- **Never scp `configuration.nix` or `agent-config.nix` directly** — the local copies have placeholder values. Either edit on the server, or use `setup.sh` for a fresh install.
+- The deploy script skips both `configuration.nix` and `agent-config.nix` automatically (it only copies the supporting `.nix` files and scripts).
 - First Rust build on a fresh server takes a while (downloading crates). Subsequent builds are fast thanks to cached target directory.
 
 ### Claude OAuth token refresh

--- a/dashboard/backend/src/config.rs
+++ b/dashboard/backend/src/config.rs
@@ -31,9 +31,9 @@ impl Config {
             google_client_secret: env::var("GOOGLE_CLIENT_SECRET")?,
             google_redirect_uri: env::var("GOOGLE_REDIRECT_URI")?,
             allowed_domain: env::var("ALLOWED_DOMAIN")
-                .unwrap_or_else(|_| "lambdaclass.com".into()),
+                .unwrap_or_else(|_| "example.com".into()),
             preview_domain: env::var("PREVIEW_DOMAIN")
-                .unwrap_or_else(|_| "hipermegared.link".into()),
+                .unwrap_or_else(|_| "example.com".into()),
             allowed_repos: env::var("ALLOWED_REPOS")
                 .unwrap_or_default()
                 .split(',')

--- a/dashboard/backend/src/main.rs
+++ b/dashboard/backend/src/main.rs
@@ -4,6 +4,7 @@ mod db;
 mod error;
 mod models;
 mod previews;
+mod public_config;
 mod shell;
 mod tasks;
 mod ws;
@@ -50,6 +51,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let api = Router::new()
+        // Public config
+        .route("/config", get(public_config::get_config))
         // Auth
         .route("/auth/login", get(auth::login))
         .route("/auth/callback", get(auth::callback))

--- a/dashboard/backend/src/public_config.rs
+++ b/dashboard/backend/src/public_config.rs
@@ -1,0 +1,18 @@
+use axum::extract::State;
+use axum::Json;
+use serde::Serialize;
+
+use crate::AppState;
+
+#[derive(Serialize)]
+pub struct PublicConfig {
+    pub preview_domain: String,
+    pub allowed_domain: String,
+}
+
+pub async fn get_config(State(state): State<AppState>) -> Json<PublicConfig> {
+    Json(PublicConfig {
+        preview_domain: state.config.preview_domain.clone(),
+        allowed_domain: state.config.allowed_domain.clone(),
+    })
+}

--- a/dashboard/backend/src/shell.rs
+++ b/dashboard/backend/src/shell.rs
@@ -399,21 +399,21 @@ mod tests {
     fn test_parse_preview_list() {
         let output = "\
 SLUG                STATUS          BRANCH                          URL
-123                 running         feat/foo                        https://123.hipermegared.link
-456                 stopped         main                            https://456.hipermegared.link
+123                 running         feat/foo                        https://123.example.com
+456                 stopped         main                            https://456.example.com
 ";
-        let result = parse_preview_list(output, "hipermegared.link").unwrap();
+        let result = parse_preview_list(output, "example.com").unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].slug, "123");
         assert_eq!(result[0].branch, "feat/foo");
-        assert_eq!(result[0].url, "https://123.hipermegared.link");
+        assert_eq!(result[0].url, "https://123.example.com");
         assert_eq!(result[1].slug, "456");
     }
 
     #[test]
     fn test_parse_empty_preview_list() {
         let output = "No active previews.\n";
-        let result = parse_preview_list(output, "hipermegared.link").unwrap();
+        let result = parse_preview_list(output, "example.com").unwrap();
         assert_eq!(result.len(), 0);
     }
 }

--- a/dashboard/deploy.sh
+++ b/dashboard/deploy.sh
@@ -42,4 +42,4 @@ echo "=== Checking status ==="
 ssh "$SERVER" "systemctl status dashboard --no-pager" || true
 
 echo ""
-echo "=== Done! Dashboard should be available at https://dashboard.hipermegared.link ==="
+echo "=== Done! Dashboard should be available at your configured domain ==="

--- a/dashboard/frontend/src/components/Layout.tsx
+++ b/dashboard/frontend/src/components/Layout.tsx
@@ -50,7 +50,7 @@ export default function Layout() {
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-4">Preview Dashboard</h1>
           <p className="text-muted-foreground mb-6">
-            Sign in with your @lambdaclass.com Google account
+            Sign in with your Google account
           </p>
           <Button asChild size="lg">
             <a href="/api/auth/login">Sign in with Google</a>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -73,6 +73,13 @@ async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
   return res.json();
 }
 
+// Config
+export interface PublicConfig {
+  preview_domain: string;
+  allowed_domain: string;
+}
+export const getConfig = () => apiFetch<PublicConfig>('/api/config');
+
 // Auth
 export const getMe = () => apiFetch<UserInfo>('/api/auth/me');
 export const logout = () => fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });

--- a/dashboard/frontend/src/pages/PreviewDetail.tsx
+++ b/dashboard/frontend/src/pages/PreviewDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ChevronLeft, ExternalLink } from 'lucide-react';
 import LogViewer from '@/components/LogViewer';
-import { connectPreviewLogs } from '@/lib/api';
+import { connectPreviewLogs, getConfig } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -12,6 +12,11 @@ export default function PreviewDetail() {
   const navigate = useNavigate();
   const [ws, setWs] = useState<WebSocket | null>(null);
   const [connected, setConnected] = useState(false);
+  const [previewDomain, setPreviewDomain] = useState<string | null>(null);
+
+  useEffect(() => {
+    getConfig().then((cfg) => setPreviewDomain(cfg.preview_domain)).catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (!slug) return;
@@ -26,7 +31,7 @@ export default function PreviewDetail() {
     };
   }, [slug]);
 
-  const previewUrl = slug ? `https://${slug}.hipermegared.link` : '';
+  const previewUrl = slug && previewDomain ? `https://${slug}.${previewDomain}` : '';
 
   return (
     <div>

--- a/dashboard/setup.sh
+++ b/dashboard/setup.sh
@@ -111,8 +111,8 @@ echo ""
 # Step 2: Domain
 # =============================================================================
 echo -e "${BOLD}--- Domain Configuration ---${NC}"
-prompt DOMAIN "Preview domain (e.g., hipermegared.link)"
-prompt ALLOWED_DOMAIN "Allowed email domain for login (e.g., lambdaclass.com)"
+prompt DOMAIN "Preview domain (e.g., yourdomain.com)"
+prompt ALLOWED_DOMAIN "Allowed email domain for login (e.g., yourdomain.com)"
 echo ""
 
 # =============================================================================
@@ -296,9 +296,9 @@ trap "rm -rf $TMPDIR" EXIT
 cp "$SERVER_CONFIG/agent-config.nix" "$TMPDIR/agent-config.nix"
 # The local file already has the right structure, just needs key substitution
 # We handle this by using sed to replace placeholder keys
-sed -i.bak "s|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEWMu5wyCIJclVNVk3Judmu5zkWxkbtTJrcC0BpEcVfy jrchatruc@gmail.com|${SSH_PUBKEY}|g" "$TMPDIR/agent-config.nix"
-sed -i.bak "s|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBIrWQgyW2acM35arp+DVr8Jo5S7A4vqbP9gLk3pMRhw root@nixos-server|${ROOT_PUBKEY}|g" "$TMPDIR/agent-config.nix"
-sed -i.bak "s|email = jrchatruc@gmail.com|email = ${GIT_EMAIL}|g" "$TMPDIR/agent-config.nix"
+sed -i.bak "s|ssh-ed25519 AAAA\.\.\. your-key-here|${SSH_PUBKEY}|g" "$TMPDIR/agent-config.nix"
+sed -i.bak "s|ssh-ed25519 AAAA\.\.\. root-key-here|${ROOT_PUBKEY}|g" "$TMPDIR/agent-config.nix"
+sed -i.bak "s|email = YOUR_GIT_EMAIL|email = ${GIT_EMAIL}|g" "$TMPDIR/agent-config.nix"
 
 # Upload NixOS configs
 scp "$TMPDIR/agent-config.nix" "$SERVER:/etc/nixos/agent-config.nix"

--- a/deploy.sh
+++ b/deploy.sh
@@ -116,10 +116,10 @@ deploy_webhook() {
 
 deploy_nix() {
     info "Deploying NixOS configs..."
-    # Copy everything EXCEPT configuration.nix (has placeholders)
+    # Copy everything EXCEPT configuration.nix and agent-config.nix (have placeholders)
     $SSH "
         cd ${REMOTE_SRC}/server-config && \
-        for f in agent-config.nix agent.sh preview-config.nix vertex-preview-config.nix preview.sh flake.nix; do
+        for f in agent.sh preview-config.nix vertex-preview-config.nix preview.sh flake.nix; do
             if [ -f \"\$f\" ]; then
                 cp \"\$f\" /etc/nixos/\"\$f\"
             fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ Browser: https://42.preview.example.com/api/users
 
 | File | Flake output | Purpose |
 |------|-------------|---------|
-| `server-config/agent-config.nix` | `nixosConfigurations.agent` | Agent container (Claude Code + dev tools) |
+| `server-config/agent-config.nix` | `nixosConfigurations.agent` | Agent container (Claude Code + dev tools). Has placeholders: `YOUR_GIT_EMAIL`, SSH key placeholders |
 | `server-config/preview-config.nix` | `nixosConfigurations.preview` | Node.js preview container |
 | `server-config/vertex-preview-config.nix` | `nixosConfigurations.vertex-preview` | Vertex preview container (Elixir + React) |
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -176,17 +176,17 @@ The Caddy configuration may need a plugin hash that's unknown on first build. Th
 
 ## Updating the Server
 
-After making changes to files in `server-config/`:
+After making changes to files in `server-config/`, use `deploy.sh` or copy individual files. **Do not copy `configuration.nix` or `agent-config.nix` — they have placeholders.**
 
 ```bash
-# Copy updated files to the server
-scp -r server-config/. root@YOUR_SERVER_IP:/etc/nixos/
+# Copy specific updated files (NOT configuration.nix or agent-config.nix)
+scp server-config/preview.sh server-config/agent.sh server-config/flake.nix root@YOUR_SERVER_IP:/etc/nixos/
 
 # Rebuild on the server
 ssh root@YOUR_SERVER_IP 'cd /etc/nixos && nixos-rebuild switch'
 ```
 
-**Important**: Never `scp` the local `configuration.nix` directly — it has placeholder values (`YOUR.SERVER.IP.HERE`) that will break networking. Either edit on the server, or use `setup.sh` for a fresh install.
+**Important**: Never `scp` template NixOS configs (`configuration.nix`, `agent-config.nix`) directly — they have placeholder values that `setup.sh` substitutes with real values. Key placeholders include `YOUR.SERVER.IP.HERE`, `YOUR.GATEWAY.IP.HERE`, `dashboard.YOUR_DOMAIN`, `YOUR_GIT_EMAIL`, and SSH key placeholders (`ssh-ed25519 AAAA... your-key-here`, `ssh-ed25519 AAAA... root-key-here`). Either edit on the server, or use `setup.sh` for a fresh install.
 
 To update the webhook after code changes:
 

--- a/docs/preview-deployments.md
+++ b/docs/preview-deployments.md
@@ -32,7 +32,7 @@ preview create myorg/myapp feature-branch
 preview create myorg/myapp feature-branch --slug myapp-pr-42
 
 # Vertex (Elixir/Phoenix) app
-preview create lambdaclass/vertex feature-branch --type vertex --slug vtx-pr-42
+preview create myorg/myapp feature-branch --type vertex --slug vtx-pr-42
 ```
 
 Options:

--- a/server-config/agent-config.nix
+++ b/server-config/agent-config.nix
@@ -50,7 +50,7 @@ EOF
       cat > /home/agent/.gitconfig << 'GITEOF'
 [user]
 	name = Claude (Dashboard)
-	email = jrchatruc@gmail.com
+	email = YOUR_GIT_EMAIL
 [gpg]
 	format = ssh
 [user]
@@ -75,8 +75,8 @@ GITEOF
     shell = pkgs.bash;
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEWMu5wyCIJclVNVk3Judmu5zkWxkbtTJrcC0BpEcVfy jrchatruc@gmail.com"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBIrWQgyW2acM35arp+DVr8Jo5S7A4vqbP9gLk3pMRhw root@nixos-server"
+      "ssh-ed25519 AAAA... your-key-here"
+      "ssh-ed25519 AAAA... root-key-here"
     ];
   };
 
@@ -85,8 +85,8 @@ GITEOF
   users.users.root = {
     password = "changeme";  # Fallback password
     openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEWMu5wyCIJclVNVk3Judmu5zkWxkbtTJrcC0BpEcVfy jrchatruc@gmail.com"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBIrWQgyW2acM35arp+DVr8Jo5S7A4vqbP9gLk3pMRhw root@nixos-server"
+      "ssh-ed25519 AAAA... your-key-here"
+      "ssh-ed25519 AAAA... root-key-here"
     ];
   };
 

--- a/server-config/configuration.nix
+++ b/server-config/configuration.nix
@@ -102,7 +102,7 @@
         tls /var/secrets/cloudflare-origin.pem /var/secrets/cloudflare-origin-key.pem
       }
 
-      dashboard.hipermegared.link {
+      dashboard.YOUR_DOMAIN {
         import cloudflare_tls
         reverse_proxy localhost:3200
       }

--- a/server-config/preview.sh
+++ b/server-config/preview.sh
@@ -641,7 +641,7 @@ cmd_help() {
     echo "  preview build --type vertex"
     echo "  preview create myorg/myapp feature-branch"
     echo "  preview create myorg/myapp feature-branch --slug myapp-pr-42"
-    echo "  preview create lambdaclass/vertex feature-branch --type vertex --slug vtx-pr-42"
+    echo "  preview create myorg/myapp feature-branch --type vertex --slug vtx-pr-42"
     echo "  preview logs myapp-pr-42 --follow"
     echo "  preview update myapp-pr-42"
     echo "  preview destroy myapp-pr-42"


### PR DESCRIPTION
## Summary

- Replace all hardcoded domain names, personal email, and SSH keys with configurable placeholders so the project is generic and deployable by anyone
- Add a public `/api/config` endpoint so the frontend dynamically gets `preview_domain` instead of hardcoding it
- Exclude `agent-config.nix` from `deploy.sh` since it now has placeholders (same as `configuration.nix`)
- Update all documentation with a comprehensive placeholder reference table

## Test plan

- [x] Backend compiles (`cargo build`)
- [x] Backend tests pass (`cargo test` — 3/3)
- [x] Frontend builds (`npm run build`)
- [x] Grep confirms zero remaining hardcoded values in source files