### PR TITLE
Replace repo auto-classifier with simple repo dropdown

### DIFF
--- a/dashboard/backend/src/main.rs
+++ b/dashboard/backend/src/main.rs
@@ -75,8 +75,8 @@ async fn main() -> anyhow::Result<()> {
         .route("/tasks/{id}/actions", get(tasks::list_actions))
         // Uploads
         .route("/uploads", post(tasks::upload_image))
-        // Classify
-        .route("/classify", post(tasks::classify))
+        // Repos
+        .route("/repos", get(tasks::list_repos))
         // WebSockets
         .route("/ws/logs/{slug}", get(ws::preview_logs_ws))
         .route("/ws/tasks/{id}", get(ws::task_output_ws));

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -10,8 +10,8 @@ use crate::auth::AuthUser;
 use crate::config::Config;
 use crate::error::AppError;
 use crate::models::{
-    ClassifyRequest, ClassifyResponse, CreateTaskRequest, ListMessagesQuery, ListTasksQuery,
-    PaginatedTasks, SendMessageRequest, Task, TaskAction, TaskLog, TaskMessage,
+    CreateTaskRequest, ListMessagesQuery, ListTasksQuery, PaginatedTasks, SendMessageRequest,
+    Task, TaskAction, TaskLog, TaskMessage,
 };
 use crate::shell;
 
@@ -1195,63 +1195,19 @@ async fn take_screenshot(
     }
 }
 
-// ── Classify ──
+// ── Repos ──
 
-pub async fn classify(
+pub async fn list_repos(
     _user: AuthUser,
     State(state): State<crate::AppState>,
-    Json(req): Json<ClassifyRequest>,
-) -> Result<Json<ClassifyResponse>, AppError> {
-    if state.config.allowed_repos.is_empty() {
-        return Err(AppError::BadRequest("No allowed repos configured".into()));
-    }
+) -> Result<Json<Vec<String>>, AppError> {
+    let rows = sqlx::query_scalar::<_, String>(
+        "SELECT DISTINCT repo FROM tasks ORDER BY repo"
+    )
+    .fetch_all(&state.db)
+    .await?;
 
-    let repo_list = state
-        .config
-        .allowed_repos
-        .iter()
-        .enumerate()
-        .map(|(i, r)| format!("{}. {}", i + 1, r))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let system_prompt = format!(
-        "You are a repository classifier. Given a task description, pick the single best matching \
-         repository from this list and respond with ONLY the repo name (owner/repo format), nothing else.\n\n\
-         Available repositories:\n{repo_list}"
-    );
-
-    let full_prompt = format!("{system_prompt}\n\nTask: {}", req.prompt);
-    let escaped = full_prompt.replace('\'', "'\\''");
-
-    // Run claude CLI on the host using the long-lived OAuth token
-    let oauth_token = read_claude_oauth_token().await?;
-    let output = tokio::process::Command::new(&state.config.claude_bin)
-        .env("CLAUDE_CODE_OAUTH_TOKEN", &oauth_token)
-        .args(["--dangerously-skip-permissions", "-p", &escaped])
-        .output()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to run claude for classification: {e}")))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    // Find which allowed repo the response matches
-    let repo = state
-        .config
-        .allowed_repos
-        .iter()
-        .find(|r| stdout.contains(r.as_str()))
-        .cloned()
-        .unwrap_or_else(|| {
-            // Fallback: return the raw output truncated, or first repo
-            if stdout.is_empty() {
-                state.config.allowed_repos[0].clone()
-            } else {
-                stdout.lines().next().unwrap_or("").to_string()
-            }
-        });
-
-    Ok(Json(ClassifyResponse { repo }))
+    Ok(Json(rows))
 }
 
 // ── Messages ──

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -177,11 +177,7 @@ export function parseImageUrls(raw: string | null | undefined): string[] {
     return [raw];
   }
 }
-export const classifyPrompt = (prompt: string) =>
-  apiFetch<{ repo: string }>('/api/classify', {
-    method: 'POST',
-    body: JSON.stringify({ prompt }),
-  });
+export const listRepos = () => apiFetch<string[]>('/api/repos');
 
 // WebSocket helpers
 export function connectPreviewLogs(slug: string): WebSocket {

--- a/dashboard/frontend/src/pages/Tasks.tsx
+++ b/dashboard/frontend/src/pages/Tasks.tsx
@@ -1,7 +1,7 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { listTasks, createTask, classifyPrompt, uploadImage, type ListTasksParams } from '@/lib/api';
+import { listTasks, createTask, listRepos, uploadImage, type ListTasksParams } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -58,46 +58,23 @@ export default function Tasks() {
   const [prompt, setPrompt] = useState('');
   const [repo, setRepo] = useState('');
   const [baseBranch, setBaseBranch] = useState('main');
-  const [repoAutoDetected, setRepoAutoDetected] = useState(false);
   const [imageFiles, setImageFiles] = useState<File[]>([]);
   const [imagePreviews, setImagePreviews] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
   const imageInputRef = useRef<HTMLInputElement>(null);
 
-  const classifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const scheduleClassify = useCallback((text: string) => {
-    if (classifyTimerRef.current) clearTimeout(classifyTimerRef.current);
-    if (text.length <= 20) return;
-    classifyTimerRef.current = setTimeout(async () => {
-      try {
-        const result = await classifyPrompt(text);
-        if (result.repo) {
-          setRepo(result.repo);
-          setRepoAutoDetected(true);
-        }
-      } catch {
-        // silently ignore classify errors
-      }
-    }, 1000);
-  }, []);
+  const { data: knownRepos } = useQuery({
+    queryKey: ['repos'],
+    queryFn: listRepos,
+  });
 
   const handlePromptChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setPrompt(e.target.value);
-    setRepoAutoDetected(false);
-    scheduleClassify(e.target.value);
   };
 
   const handleTranscript = (text: string) => {
     const next = prompt ? `${prompt} ${text}` : text;
     setPrompt(next);
-    setRepoAutoDetected(false);
-    scheduleClassify(next);
-  };
-
-  const handleRepoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setRepo(e.target.value);
-    setRepoAutoDetected(false);
   };
 
   const addImageFiles = (files: FileList | File[]) => {
@@ -132,7 +109,6 @@ export default function Tasks() {
       setPrompt('');
       setRepo('');
       setBaseBranch('main');
-      setRepoAutoDetected(false);
       setImageFiles([]);
       setImagePreviews([]);
     },
@@ -252,19 +228,20 @@ export default function Tasks() {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <Label htmlFor="task-repo">Repository</Label>
-                      {repoAutoDetected && (
-                        <span className="text-xs text-muted-foreground">auto-detected</span>
-                      )}
-                    </div>
+                    <Label htmlFor="task-repo">Repository</Label>
                     <Input
                       id="task-repo"
+                      list="repo-options"
                       value={repo}
-                      onChange={handleRepoChange}
+                      onChange={(e) => setRepo(e.target.value)}
                       placeholder="owner/repo"
                       required
                     />
+                    <datalist id="repo-options">
+                      {knownRepos?.map((r) => (
+                        <option key={r} value={r} />
+                      ))}
+                    </datalist>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="base-branch">Base Branch</Label>


### PR DESCRIPTION
## Summary

- Removes the AI-powered repo classifier (`POST /classify` endpoint) — it was slow and unreliable
- Adds `GET /api/repos` endpoint returning distinct repos from existing tasks
- Repo input now shows a dropdown of previously used repos via native `<datalist>`
- Users can still type any new `owner/repo` manually

Closes #41.

## Test plan

- [ ] Open task creation form
- [ ] Click/focus the repo field — should show dropdown of repos from past tasks
- [ ] Type to filter the dropdown
- [ ] Type a completely new repo name — should work as free-text input
- [ ] Verify no auto-classify delay when typing prompts