### PR TITLE
Add task-to-PR traceability (issue #83)

### DIFF
--- a/dashboard/backend/src/main.rs
+++ b/dashboard/backend/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/tasks/{id}/name", patch(tasks::update_task_name))
         .route("/tasks/{id}/actions", get(tasks::list_actions))
         .route("/tasks/{id}/create-pr", post(tasks::create_pr))
+        .route("/tasks/{id}/link-pr", post(tasks::link_pr))
         // Uploads
         .route("/uploads", post(tasks::upload_image))
         // Repos

--- a/dashboard/backend/src/models.rs
+++ b/dashboard/backend/src/models.rs
@@ -85,6 +85,11 @@ pub struct UpdateTaskNameRequest {
     pub name: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LinkPrRequest {
+    pub pr_url: String,
+}
+
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct TaskLog {
     pub id: i64,

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -1933,6 +1933,42 @@ pub async fn create_pr(
     Ok(Json(updated_task))
 }
 
+pub async fn link_pr(
+    _user: AuthUser,
+    State(state): State<crate::AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<crate::models::LinkPrRequest>,
+) -> Result<Json<Task>, AppError> {
+    // Extract PR number from URL (e.g. https://github.com/owner/repo/pull/123)
+    let pr_number: Option<i32> = req.pr_url
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse().ok());
+
+    sqlx::query("UPDATE tasks SET pr_url = $1, pr_number = $2, updated_at = NOW() WHERE id = $3")
+        .bind(&req.pr_url)
+        .bind(pr_number)
+        .bind(&id)
+        .execute(&state.db)
+        .await?;
+
+    let task = sqlx::query_as::<_, Task>(
+        "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
+         preview_slug, preview_url, error_message, \
+         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         parent_task_id, created_by, screenshot_url, image_url, \
+         total_input_tokens, total_output_tokens, name, pr_url, pr_number \
+         FROM tasks WHERE id = $1"
+    )
+    .bind(&id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Task not found".into()))?;
+
+    Ok(Json(task))
+}
+
 pub async fn get_task_logs(
     _user: AuthUser,
     State(state): State<crate::AppState>,

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -175,6 +175,11 @@ export const listTaskActions = (id: string) =>
   apiFetch<TaskAction[]>(`/api/tasks/${id}/actions`);
 export const createPR = (id: string) =>
   apiFetch<Task>(`/api/tasks/${id}/create-pr`, { method: 'POST' });
+export const linkPR = (id: string, pr_url: string) =>
+  apiFetch<Task>(`/api/tasks/${id}/link-pr`, {
+    method: 'POST',
+    body: JSON.stringify({ pr_url }),
+  });
 
 /** Parse image_url JSON column (stored as JSON array string) into an array of URLs. */
 export function parseImageUrls(raw: string | null | undefined): string[] {

--- a/dashboard/frontend/src/pages/Tasks.tsx
+++ b/dashboard/frontend/src/pages/Tasks.tsx
@@ -312,6 +312,17 @@ export default function Tasks() {
                   <div className="flex items-center gap-4 text-xs text-muted-foreground">
                     <span>{t.repo}</span>
                     <span>{t.base_branch}</span>
+                    {t.pr_url && (
+                      <a
+                        href={t.pr_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-blue-400 hover:text-blue-300"
+                      >
+                        PR #{t.pr_number}
+                      </a>
+                    )}
                     {t.preview_url && (
                       <span className="text-green-400">{t.preview_url}</span>
                     )}


### PR DESCRIPTION
## Summary
- **Backend**: `POST /api/tasks/{id}/link-pr` endpoint for manually linking a GitHub PR URL to a task (extracts PR number from URL)
- **Frontend**: PR badge (`PR #N`) shown in the task list cards, linking to the GitHub PR
- **Frontend**: `linkPR()` API function

Builds on PR #101 which added `pr_url`/`pr_number` fields and the "Create PR" button.

Replaces #96 (clean rewrite without cross-pollination).

Closes #83

## Test plan
- [ ] Verify tasks with a PR show "PR #N" badge in the task list
- [ ] Verify clicking the badge opens the PR in a new tab
- [ ] Test `POST /api/tasks/{id}/link-pr` with a PR URL