### PR TITLE
Auto-grant org members access to all repos under the org

### DIFF
--- a/dashboard/backend/src/auth.rs
+++ b/dashboard/backend/src/auth.rs
@@ -317,14 +317,21 @@ impl FromRequestParts<AppState> for MemberUser {
 // ── Permission helpers ──
 
 /// Check if a user has permission to access a repo.
-/// Admins always have access. Members/viewers need an entry in user_repo_permissions.
+/// Admins always have access. Members automatically have access to repos under
+/// the configured GitHub org. Others need an explicit entry in user_repo_permissions.
 pub async fn check_repo_permission(
     db: &PgPool,
     github_login: &str,
     repo: &str,
     role: &str,
+    github_org: &str,
 ) -> Result<(), AppError> {
     if role == "admin" {
+        return Ok(());
+    }
+
+    // Members of the org automatically have access to all repos under that org
+    if role == "member" && repo.starts_with(&format!("{github_org}/")) {
         return Ok(());
     }
 

--- a/dashboard/backend/src/previews.rs
+++ b/dashboard/backend/src/previews.rs
@@ -30,7 +30,7 @@ pub async fn create_preview(
     }
 
     // Check per-user repo permission
-    auth::check_repo_permission(&state.db, &user.0.sub, &req.repo, &user.0.role).await?;
+    auth::check_repo_permission(&state.db, &user.0.sub, &req.repo, &user.0.role, &state.config.github_org).await?;
 
     let output = shell::create_preview(
         &state.config,

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -23,8 +23,9 @@ async fn check_repo_permission(
     github_login: &str,
     repo: &str,
     role: &str,
+    github_org: &str,
 ) -> Result<(), AppError> {
-    auth::check_repo_permission(db, github_login, repo, role).await
+    auth::check_repo_permission(db, github_login, repo, role, github_org).await
 }
 
 /// Delegate to auth module's check_task_ownership.
@@ -304,7 +305,7 @@ pub async fn create_task(
     }
 
     // Check per-user repo permission
-    check_repo_permission(&state.db, &user.0.sub, &req.repo, &user.0.role).await?;
+    check_repo_permission(&state.db, &user.0.sub, &req.repo, &user.0.role, &state.config.github_org).await?;
 
     // Validate parent_task_id if provided
     if let Some(ref parent_id) = req.parent_task_id {
@@ -1404,7 +1405,7 @@ pub async fn list_branches(
     Path((owner, repo)): Path<(String, String)>,
 ) -> Result<Json<Vec<String>>, AppError> {
     let full_repo = format!("{owner}/{repo}");
-    check_repo_permission(&state.db, &user.0.sub, &full_repo, &user.0.role).await?;
+    check_repo_permission(&state.db, &user.0.sub, &full_repo, &user.0.role, &state.config.github_org).await?;
     let git_id = get_git_identity(&state.db, &user.0.sub).await?;
 
     let client = reqwest::Client::new();


### PR DESCRIPTION
## Summary
- Org members (verified at login via GitHub org membership check) now automatically have access to all repos under the configured `GITHUB_ORG` namespace
- No manual per-user repo assignment needed for org repos — new team members can immediately create tasks and previews
- Admins still have unrestricted access; viewers still require explicit repo grants

## Test plan
- [ ] Log in as a non-admin org member
- [ ] Verify they can create tasks/previews for `lambdaclass/*` repos without manual repo assignment
- [ ] Verify viewers still cannot access repos without explicit permission