### PR TITLE
Fix webhook deploy: clean src dir before copying

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -121,6 +121,7 @@ deploy_dashboard() {
 deploy_webhook() {
     info "Building and deploying preview webhook..."
     $SSH "
+        rm -rf /opt/preview-webhook/src && \
         cp -r ${REMOTE_SRC}/server-config/preview-webhook/src /opt/preview-webhook/src && \
         cp ${REMOTE_SRC}/server-config/preview-webhook/package*.json /opt/preview-webhook/ && \
         cp ${REMOTE_SRC}/server-config/preview-webhook/tsconfig.json /opt/preview-webhook/ && \


### PR DESCRIPTION
## Summary
- When `/opt/preview-webhook/src` already exists, `cp -r` nests the source directory inside it (creating `src/src`) instead of replacing it
- Added `rm -rf` before the copy to ensure a clean destination and remove stale files from previous deploys

## Test plan
- [ ] Deploy webhook to server and verify `/opt/preview-webhook/src` contains the expected files (no nested `src/src`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)