### PR TITLE
Show user-friendly error messages on preview creation failure

### DIFF
--- a/dashboard/backend/src/error.rs
+++ b/dashboard/backend/src/error.rs
@@ -9,6 +9,11 @@ pub enum AppError {
     NotFound(String),
     BadRequest(String),
     Internal(String),
+    /// A user-facing error with a machine-readable code for the frontend to map to friendly messages.
+    UserError {
+        code: &'static str,
+        message: String,
+    },
 }
 
 impl std::fmt::Display for AppError {
@@ -19,20 +24,30 @@ impl std::fmt::Display for AppError {
             Self::NotFound(msg) => write!(f, "Not found: {msg}"),
             Self::BadRequest(msg) => write!(f, "Bad request: {msg}"),
             Self::Internal(msg) => write!(f, "Internal error: {msg}"),
+            Self::UserError { code, message } => write!(f, "User error [{code}]: {message}"),
         }
     }
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, message) = match &self {
-            Self::Auth(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
-            Self::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
-            Self::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
-            Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
-            Self::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+        let (status, message, code) = match &self {
+            Self::Auth(msg) => (StatusCode::UNAUTHORIZED, msg.clone(), None),
+            Self::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone(), None),
+            Self::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone(), None),
+            Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone(), None),
+            Self::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone(), None),
+            Self::UserError { code, message } => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                message.clone(),
+                Some(*code),
+            ),
         };
-        let body = axum::Json(json!({ "error": message }));
+        let body = if let Some(code) = code {
+            axum::Json(json!({ "error": message, "error_code": code }))
+        } else {
+            axum::Json(json!({ "error": message }))
+        };
         (status, body).into_response()
     }
 }

--- a/dashboard/backend/src/previews.rs
+++ b/dashboard/backend/src/previews.rs
@@ -53,7 +53,8 @@ pub async fn create_preview(
         req.slug.as_deref(),
         &github_token,
     )
-    .await?;
+    .await
+    .map_err(|e| classify_create_error(e, &req.repo, req.slug.as_deref()))?;
 
     // Audit: preview.created
     crate::audit::log_event(
@@ -119,4 +120,75 @@ pub async fn update_preview(
         "message": "Preview update triggered",
         "output": output.trim(),
     })))
+}
+
+/// Inspect the raw shell error from `create_preview` and return a user-friendly
+/// `AppError::UserError` when the failure matches a known pattern.
+fn classify_create_error(err: AppError, repo: &str, slug: Option<&str>) -> AppError {
+    let msg = match &err {
+        AppError::Internal(msg) => msg.as_str(),
+        _ => return err,
+    };
+
+    let lower = msg.to_lowercase();
+
+    // Repository not accessible
+    if lower.contains("repository") && lower.contains("not found")
+        || lower.contains("could not read from remote repository")
+        || lower.contains("fatal: remote error")
+        || lower.contains("authentication failed")
+        || lower.contains("could not resolve host")
+    {
+        tracing::warn!("Preview creation failed (repo_not_accessible): {msg}");
+        return AppError::UserError {
+            code: "repo_not_accessible",
+            message: format!(
+                "Could not access repository '{repo}'. Check that the name is correct and that the deploy token has access."
+            ),
+        };
+    }
+
+    // Slug / container conflict
+    if lower.contains("already exists")
+        || lower.contains("name conflict")
+        || lower.contains("is already in use")
+    {
+        let slug_display = slug.unwrap_or("(auto)");
+        tracing::warn!("Preview creation failed (slug_conflict): {msg}");
+        return AppError::UserError {
+            code: "slug_conflict",
+            message: format!(
+                "A preview with slug '{slug_display}' already exists. Choose a different slug or destroy the existing preview first."
+            ),
+        };
+    }
+
+    // Invalid slug characters
+    if lower.contains("invalid slug")
+        || lower.contains("invalid container name")
+        || lower.contains("invalid character")
+    {
+        tracing::warn!("Preview creation failed (invalid_slug): {msg}");
+        return AppError::UserError {
+            code: "invalid_slug",
+            message: "The slug contains invalid characters. Use only lowercase letters, numbers, and hyphens.".to_string(),
+        };
+    }
+
+    // Branch not found
+    if lower.contains("did not match any")
+        || (lower.contains("pathspec") && lower.contains("did not match"))
+        || lower.contains("remote branch") && lower.contains("not found")
+    {
+        tracing::warn!("Preview creation failed (branch_not_found): {msg}");
+        return AppError::UserError {
+            code: "branch_not_found",
+            message: format!(
+                "Could not find the specified branch in '{repo}'. Check that the branch name is correct."
+            ),
+        };
+    }
+
+    // Unrecognised — keep original Internal error
+    err
 }

--- a/dashboard/backend/src/previews.rs
+++ b/dashboard/backend/src/previews.rs
@@ -175,6 +175,15 @@ fn classify_create_error(err: AppError, repo: &str, slug: Option<&str>) -> AppEr
         };
     }
 
+    // Slug too long
+    if lower.contains("is too long") {
+        tracing::warn!("Preview creation failed (slug_too_long): {msg}");
+        return AppError::UserError {
+            code: "slug_too_long",
+            message: "The slug is too long. It must be 11 characters or fewer.".to_string(),
+        };
+    }
+
     // Branch not found
     if lower.contains("did not match any")
         || (lower.contains("pathspec") && lower.contains("did not match"))

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -78,11 +78,13 @@ export interface ListTasksParams {
   per_page?: number;
 }
 
-class ApiError extends Error {
+export class ApiError extends Error {
   status: number;
-  constructor(status: number, message: string) {
+  errorCode?: string;
+  constructor(status: number, message: string, errorCode?: string) {
     super(message);
     this.status = status;
+    this.errorCode = errorCode;
   }
 }
 
@@ -100,7 +102,7 @@ async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
       throw new ApiError(401, 'Not authenticated');
     }
     const body = await res.json().catch(() => ({ error: res.statusText }));
-    throw new ApiError(res.status, body.error || res.statusText);
+    throw new ApiError(res.status, body.error || res.statusText, body.error_code);
   }
   return res.json();
 }

--- a/dashboard/frontend/src/pages/Previews.tsx
+++ b/dashboard/frontend/src/pages/Previews.tsx
@@ -24,6 +24,8 @@ const FRIENDLY_MESSAGES: Record<string, string> = {
     'The slug contains invalid characters. Use only lowercase letters, numbers, and hyphens.',
   branch_not_found:
     'The branch was not found in the repository. Please check that the branch name is correct.',
+  slug_too_long:
+    'The slug is too long. It must be 11 characters or fewer.',
 };
 
 function friendlyCreateError(error: unknown): string {

--- a/dashboard/frontend/src/pages/Previews.tsx
+++ b/dashboard/frontend/src/pages/Previews.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { listPreviews, createPreview, destroyPreview } from '@/lib/api';
+import { listPreviews, createPreview, destroyPreview, ApiError } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -14,6 +14,25 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+
+const FRIENDLY_MESSAGES: Record<string, string> = {
+  repo_not_accessible:
+    'The repository could not be accessed. Please check that the name is correct (owner/repo) and that the deploy token has permission.',
+  slug_conflict:
+    'A preview with that slug already exists. Choose a different slug or destroy the existing preview first.',
+  invalid_slug:
+    'The slug contains invalid characters. Use only lowercase letters, numbers, and hyphens.',
+  branch_not_found:
+    'The branch was not found in the repository. Please check that the branch name is correct.',
+};
+
+function friendlyCreateError(error: unknown): string {
+  if (error instanceof ApiError && error.errorCode) {
+    return FRIENDLY_MESSAGES[error.errorCode] ?? error.message;
+  }
+  if (error instanceof Error) return error.message;
+  return 'An unexpected error occurred.';
+}
 
 export default function Previews() {
   const queryClient = useQueryClient();
@@ -139,7 +158,7 @@ export default function Previews() {
               </Button>
               {createMutation.isError && (
                 <p className="mt-2 text-destructive text-sm">
-                  {(createMutation.error as Error).message}
+                  {friendlyCreateError(createMutation.error)}
                 </p>
               )}
             </form>


### PR DESCRIPTION
## Summary

Closes #141

- Add `UserError` variant to `AppError` with machine-readable `error_code` field (HTTP 422)
- Classify shell stderr from preview creation into known error codes: `repo_not_accessible`, `slug_conflict`, `invalid_slug`, `branch_not_found`
- Export `ApiError` with `errorCode` in the frontend API client
- Map error codes to clear, actionable messages on the Previews create form

## Test plan

- [ ] Trigger a clone failure (e.g., nonexistent repo) and verify friendly "Could not access repository" message appears
- [ ] Create a preview with a slug that already exists and verify slug conflict message
- [ ] Verify unrecognized errors still display the raw server message as fallback
- [ ] `cargo test` passes
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)