### PR TITLE
Add VS Code button to open task branch on github.dev

### DIFF
--- a/dashboard/frontend/src/pages/TaskDetail.tsx
+++ b/dashboard/frontend/src/pages/TaskDetail.tsx
@@ -18,6 +18,7 @@ import {
   Image as ImageIcon,
   MessageSquare,
   CheckCircle,
+  Code,
 } from 'lucide-react';
 import LogViewer from '@/components/LogViewer';
 import TaskChat from '@/components/TaskChat';
@@ -212,6 +213,18 @@ export default function TaskDetail() {
               <Button size="sm" variant="outline">
                 <GitPullRequest className="size-3.5 mr-1" />
                 PR #{task.pr_number}
+              </Button>
+            </a>
+          )}
+          {task?.branch_name && (
+            <a
+              href={`https://github.dev/${task.repo}/tree/${task.branch_name}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button size="sm" variant="outline">
+                <Code className="size-3.5 mr-1" />
+                VS Code
               </Button>
             </a>
           )}

--- a/dashboard/frontend/src/pages/Tasks.tsx
+++ b/dashboard/frontend/src/pages/Tasks.tsx
@@ -14,7 +14,7 @@ import { statusVariant } from '@/lib/status';
 import { timeAgo, formatCost } from '@/lib/utils';
 import VoiceInput from '@/components/VoiceInput';
 import BranchCombobox from '@/components/BranchCombobox';
-import { ImagePlus, X, ChevronLeft, ChevronRight, Search, BrainCircuit, LayoutGrid, List } from 'lucide-react';
+import { ImagePlus, X, ChevronLeft, ChevronRight, Search, BrainCircuit, LayoutGrid, List, Code } from 'lucide-react';
 
 type ViewMode = 'card' | 'list';
 const VIEW_STORAGE_KEY = 'tekton-task-view';
@@ -489,6 +489,18 @@ export default function Tasks() {
                           PR #{t.pr_number}
                         </a>
                       )}
+                      {t.branch_name && (
+                        <a
+                          href={`https://github.dev/${t.repo}/tree/${t.branch_name}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="shrink-0 inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                        >
+                          <Code className="size-3" />
+                          VS Code
+                        </a>
+                      )}
                       {t.preview_url && (
                         <a
                           href={t.preview_url}
@@ -559,6 +571,18 @@ export default function Tasks() {
                 <Badge variant="outline" className="shrink-0 text-[10px] px-1.5 py-0">
                   {t.repo.split('/').pop()}
                 </Badge>
+                {t.branch_name && (
+                  <a
+                    href={`https://github.dev/${t.repo}/tree/${t.branch_name}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="shrink-0 text-blue-400 hover:text-blue-300"
+                    title="Open in VS Code"
+                  >
+                    <Code className="size-3.5" />
+                  </a>
+                )}
                 {t.total_cost_usd ? (
                   <span className="shrink-0 text-xs text-muted-foreground tabular-nums w-14 text-right">
                     {formatCost(t.total_cost_usd)}


### PR DESCRIPTION
## Summary
- Adds a "VS Code" button on the task detail page and task list (card + list views) that opens the task's branch in GitHub's web-based VS Code editor (`github.dev`)
- Button is only shown when the task has a `branch_name`

## Test plan
- [ ] Verify the VS Code button appears on task detail page when a task has a branch
- [ ] Verify clicking it opens `github.dev/{repo}/tree/{branch}` in a new tab
- [ ] Verify the link appears in both card and list views on the tasks page
- [ ] Verify the button does not appear for tasks without a branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)