### PR TITLE
Fix container IP overflow by recycling slots and expanding to /16

### DIFF
--- a/server-config/agent.sh
+++ b/server-config/agent.sh
@@ -6,7 +6,7 @@
 AGENT_DIR="/var/lib/claude-agents"
 CREDS_DIR="/var/secrets/claude"
 FLAKE_DIR="/etc/nixos"
-SUBNET="10.100.0"
+SUBNET_PREFIX="10.100"
 SYSTEM_PATH_CACHE="$AGENT_DIR/.system-path"
 
 # -- Helpers ------------------------------------------------------------------
@@ -56,31 +56,57 @@ get_system_path() {
 
 # -- IP allocation ------------------------------------------------------------
 # Each container gets a pair: host-address .{N*2} / local-address .{N*2+1}
-# Counter stored in $AGENT_DIR/.next_slot, starts at 1
+# Slots are recycled: we scan tracking files to find used slots, then pick
+# the lowest available one.  Max slot is 127 (produces .254/.255).
 
-next_slot() {
-    local slot_file="$AGENT_DIR/.next_slot"
-    local slot
-    if [[ -f "$slot_file" ]]; then
-        slot=$(cat "$slot_file")
-    else
-        slot=1
-    fi
-    echo "$slot"
+MAX_SLOT=32512
+
+used_slots() {
+    # Collect slot numbers from agent tracking files ($AGENT_DIR/<name>)
+    # and preview tracking files ($PREVIEW_DIR/<slug>).  Format: "slot ..."
+    local dir file slot
+    for dir in "$AGENT_DIR" "/var/lib/preview-deploys"; do
+        [[ -d "$dir" ]] || continue
+        for file in "$dir"/*; do
+            [[ -f "$file" ]] || continue
+            local name
+            name=$(basename "$file")
+            [[ "$name" == .* ]] && continue
+            [[ "$name" == *.type ]] && continue
+            [[ "$name" == *.meta ]] && continue
+            [[ "$name" == *.sha ]] && continue
+            slot=$(awk '{print $1}' "$file")
+            [[ "$slot" =~ ^[0-9]+$ ]] && echo "$slot"
+        done
+    done
 }
 
-bump_slot() {
-    local slot_file="$AGENT_DIR/.next_slot"
-    local current
-    current=$(next_slot)
-    echo $(( current + 1 )) > "$slot_file"
+next_slot() {
+    local -A in_use
+    local s
+    while read -r s; do
+        in_use[$s]=1
+    done < <(used_slots)
+
+    local slot
+    for (( slot=1; slot<=MAX_SLOT; slot++ )); do
+        if [[ -z "${in_use[$slot]:-}" ]]; then
+            echo "$slot"
+            return
+        fi
+    done
+    fatal "No free IP slots available (all $MAX_SLOT slots in use)."
 }
 
 slot_to_ips() {
     local slot="$1"
-    local host_last=$(( slot * 2 ))
-    local local_last=$(( slot * 2 + 1 ))
-    echo "${SUBNET}.${host_last}" "${SUBNET}.${local_last}"
+    local host_flat=$(( slot * 2 ))
+    local local_flat=$(( slot * 2 + 1 ))
+    local host_third=$(( host_flat / 256 ))
+    local host_fourth=$(( host_flat % 256 ))
+    local local_third=$(( local_flat / 256 ))
+    local local_fourth=$(( local_flat % 256 ))
+    echo "${SUBNET_PREFIX}.${host_third}.${host_fourth}" "${SUBNET_PREFIX}.${local_third}.${local_fourth}"
 }
 
 # -- Commands -----------------------------------------------------------------
@@ -133,9 +159,8 @@ cmd_create() {
     mkdir -p "$creds_dest"
     cp -r "${CREDS_DIR}"/. "$creds_dest/"
 
-    # Track the agent
+    # Track the agent (this also reserves the slot for future allocations)
     echo "${slot} ${host_ip} ${local_ip}" > "$AGENT_DIR/$name"
-    bump_slot
 
     # Start the container
     nixos-container start "$name"

--- a/server-config/agent.sh
+++ b/server-config/agent.sh
@@ -57,7 +57,7 @@ get_system_path() {
 # -- IP allocation ------------------------------------------------------------
 # Each container gets a pair: host-address .{N*2} / local-address .{N*2+1}
 # Slots are recycled: we scan tracking files to find used slots, then pick
-# the lowest available one.  Max slot is 127 (produces .254/.255).
+# the lowest available one.  Uses a /16 subnet (10.100.0.0–10.100.255.255).
 
 MAX_SLOT=32512
 

--- a/server-config/configuration.nix
+++ b/server-config/configuration.nix
@@ -91,7 +91,7 @@
     authentication = ''
       local dashboard dashboard peer map=dashboard
       local all all peer
-      host all all 10.100.0.0/24 md5
+      host all all 10.100.0.0/16 md5
     '';
     identMap = ''
       dashboard root dashboard

--- a/server-config/preview.sh
+++ b/server-config/preview.sh
@@ -52,7 +52,7 @@ ensure_dirs() {
 
 # -- IP allocation (shared with agents) --------------------------------------
 # Slots are recycled: we scan tracking files to find used slots, then pick
-# the lowest available one.  Max slot is 127 (produces .254/.255).
+# the lowest available one.  Uses a /16 subnet (10.100.0.0–10.100.255.255).
 
 MAX_SLOT=32512
 

--- a/server-config/preview.sh
+++ b/server-config/preview.sh
@@ -12,7 +12,7 @@ PREVIEW_DIR="/var/lib/preview-deploys"
 CADDY_DIR="/etc/caddy/previews"
 FLAKE_DIR="/etc/nixos"
 SECRETS_FILE="/var/secrets/preview.env"
-SUBNET="10.100.0"
+SUBNET_PREFIX="10.100"
 CONFIG_CACHE_DIR="$PREVIEW_DIR/.config-cache"
 CLOSURE_CACHE_DIR="$PREVIEW_DIR/.closure-cache"
 
@@ -51,28 +51,55 @@ ensure_dirs() {
 }
 
 # -- IP allocation (shared with agents) --------------------------------------
+# Slots are recycled: we scan tracking files to find used slots, then pick
+# the lowest available one.  Max slot is 127 (produces .254/.255).
 
-next_slot() {
-    local slot_file="$AGENT_DIR/.next_slot"
-    if [[ -f "$slot_file" ]]; then
-        cat "$slot_file"
-    else
-        echo 1
-    fi
+MAX_SLOT=32512
+
+used_slots() {
+    local dir file slot
+    for dir in "$AGENT_DIR" "$PREVIEW_DIR"; do
+        [[ -d "$dir" ]] || continue
+        for file in "$dir"/*; do
+            [[ -f "$file" ]] || continue
+            local name
+            name=$(basename "$file")
+            [[ "$name" == .* ]] && continue
+            [[ "$name" == *.type ]] && continue
+            [[ "$name" == *.meta ]] && continue
+            [[ "$name" == *.sha ]] && continue
+            slot=$(awk '{print $1}' "$file")
+            [[ "$slot" =~ ^[0-9]+$ ]] && echo "$slot"
+        done
+    done
 }
 
-bump_slot() {
-    local slot_file="$AGENT_DIR/.next_slot"
-    local current
-    current=$(next_slot)
-    echo $(( current + 1 )) > "$slot_file"
+next_slot() {
+    local -A in_use
+    local s
+    while read -r s; do
+        in_use[$s]=1
+    done < <(used_slots)
+
+    local slot
+    for (( slot=1; slot<=MAX_SLOT; slot++ )); do
+        if [[ -z "${in_use[$slot]:-}" ]]; then
+            echo "$slot"
+            return
+        fi
+    done
+    fatal "No free IP slots available (all $MAX_SLOT slots in use)."
 }
 
 slot_to_ips() {
     local slot="$1"
-    local host_last=$(( slot * 2 ))
-    local local_last=$(( slot * 2 + 1 ))
-    echo "${SUBNET}.${host_last}" "${SUBNET}.${local_last}"
+    local host_flat=$(( slot * 2 ))
+    local local_flat=$(( slot * 2 + 1 ))
+    local host_third=$(( host_flat / 256 ))
+    local host_fourth=$(( host_flat % 256 ))
+    local local_third=$(( local_flat / 256 ))
+    local local_fourth=$(( local_flat % 256 ))
+    echo "${SUBNET_PREFIX}.${host_third}.${host_fourth}" "${SUBNET_PREFIX}.${local_third}.${local_fourth}"
 }
 
 # -- PostgreSQL helpers -------------------------------------------------------
@@ -522,8 +549,7 @@ cmd_create() {
         --host-address "$host_ip" \
         --local-address "$local_ip"
 
-    # Claim the IP slot immediately so no concurrent create can reuse it
-    bump_slot
+    # The slot is claimed by the tracking file written below (PREVIEW_DIR/$slug)
 
     # Write container environment files
     local container_root="/var/lib/nixos-containers/${slug}"


### PR DESCRIPTION
## Summary
- **Bug**: The monotonic `.next_slot` counter never reclaimed slots from destroyed containers. After 128 cumulative creates, IPs exceeded the valid /24 range (e.g. `10.100.0.257`), crashing container startup.
- **Fix**: Replace the counter with slot recycling — scans active tracking files to find the lowest free slot. Destroyed containers automatically release their slots.
- **Subnet expansion**: Widen from `/24` to `/16` (`10.100.0.0–10.100.255.255`) to support up to 32k concurrent containers. Updated PostgreSQL ACL accordingly.

## Test plan
- [ ] Deploy to server and verify `agent create` assigns a valid IP in the `10.100.0.x` range
- [ ] Create and destroy several containers, then create again — verify slots are recycled
- [ ] Verify PostgreSQL is reachable from new containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)