### PR TITLE
Add admin cleanup: delete tasks and orphaned previews

### DIFF
--- a/dashboard/backend/src/main.rs
+++ b/dashboard/backend/src/main.rs
@@ -128,6 +128,12 @@ async fn main() -> anyhow::Result<()> {
             "/admin/settings/ai",
             delete(settings::delete_global_ai_settings),
         )
+        // Admin: Cleanup
+        .route("/admin/tasks/{id}", delete(tasks::admin_delete_task))
+        .route(
+            "/admin/cleanup/orphaned-previews",
+            get(previews::list_orphaned_previews),
+        )
         // Admin: Audit Log
         .route("/admin/audit-log", get(audit::list_audit_log))
         // Settings

--- a/dashboard/backend/src/models.rs
+++ b/dashboard/backend/src/models.rs
@@ -111,6 +111,12 @@ pub struct UpdateTaskNameRequest {
     pub name: String,
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub struct DeleteTaskRequest {
+    #[serde(default)]
+    pub delete_branch: bool,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct LinkPrRequest {
     pub pr_url: String,

--- a/dashboard/backend/src/previews.rs
+++ b/dashboard/backend/src/previews.rs
@@ -1,7 +1,7 @@
 use axum::extract::{Path, State};
 use axum::Json;
 
-use crate::auth::{self, AuthUser, MemberUser};
+use crate::auth::{self, AdminUser, AuthUser, MemberUser};
 use crate::error::AppError;
 use crate::models::{CreatePreviewRequest, Preview};
 use crate::shell;
@@ -120,6 +120,25 @@ pub async fn update_preview(
         "message": "Preview update triggered",
         "output": output.trim(),
     })))
+}
+
+/// List previews that exist as containers but have no corresponding task in the DB.
+pub async fn list_orphaned_previews(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<Preview>>, AppError> {
+    let live = shell::list_previews(&state.config).await?;
+    let db_slugs: Vec<String> = sqlx::query_scalar(
+        "SELECT DISTINCT preview_slug FROM tasks WHERE preview_slug IS NOT NULL",
+    )
+    .fetch_all(&state.db)
+    .await?;
+
+    let orphaned = live
+        .into_iter()
+        .filter(|p| !db_slugs.contains(&p.slug))
+        .collect();
+    Ok(Json(orphaned))
 }
 
 /// Inspect the raw shell error from `create_preview` and return a user-friendly

--- a/dashboard/backend/src/shell.rs
+++ b/dashboard/backend/src/shell.rs
@@ -220,6 +220,17 @@ pub async fn update_preview(
     .await
 }
 
+/// Delete a remote git branch. Best-effort — callers should ignore errors.
+pub async fn delete_remote_branch(
+    repo: &str,
+    branch: &str,
+    github_token: &str,
+) -> Result<(), AppError> {
+    let url = format!("https://x-access-token:{github_token}@github.com/{repo}.git");
+    run_cmd("git", &["push", &url, "--delete", branch]).await?;
+    Ok(())
+}
+
 // ── Agent operations ──
 
 pub async fn create_agent(config: &Config, name: &str) -> Result<String, AppError> {

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -6,12 +6,12 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
-use crate::auth::{self, AuthUser, MemberUser};
+use crate::auth::{self, AdminUser, AuthUser, MemberUser};
 use crate::config::Config;
 use crate::error::AppError;
 use crate::models::{
-    CreateTaskRequest, ListMessagesQuery, ListTasksQuery, PaginatedTasks, SendMessageRequest, Task,
-    TaskAction, TaskLog, TaskMessage, UpdateTaskNameRequest,
+    CreateTaskRequest, DeleteTaskRequest, ListMessagesQuery, ListTasksQuery, PaginatedTasks,
+    SendMessageRequest, Task, TaskAction, TaskLog, TaskMessage, UpdateTaskNameRequest,
 };
 use crate::policies;
 use crate::secrets;
@@ -3366,4 +3366,138 @@ pub async fn get_task_logs(
     .fetch_all(&state.db)
     .await?;
     Ok(Json(logs))
+}
+
+/// Admin-only: cascade-delete a task and all its descendants.
+/// Destroys associated agent containers, previews, and optionally remote branches.
+pub async fn admin_delete_task(
+    admin: AdminUser,
+    State(state): State<crate::AppState>,
+    Path(id): Path<String>,
+    body: Option<Json<DeleteTaskRequest>>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let delete_branch = body.map(|b| b.delete_branch).unwrap_or(false);
+
+    // 1. Verify the root task exists
+    let _root = sqlx::query_scalar::<_, String>("SELECT id FROM tasks WHERE id = $1")
+        .bind(&id)
+        .fetch_optional(&state.db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Task {id} not found")))?;
+
+    // 2. Collect all descendant task IDs via recursive CTE
+    let descendant_ids: Vec<String> = sqlx::query_scalar::<_, String>(
+        "WITH RECURSIVE descendants AS ( \
+           SELECT id FROM tasks WHERE id = $1 \
+           UNION ALL \
+           SELECT t.id FROM tasks t JOIN descendants d ON t.parent_task_id = d.id \
+         ) SELECT id FROM descendants",
+    )
+    .bind(&id)
+    .fetch_all(&state.db)
+    .await?;
+
+    // 3. Fetch task details for resource cleanup
+    struct TaskResources {
+        agent_name: Option<String>,
+        preview_slug: Option<String>,
+        branch_name: Option<String>,
+        repo: String,
+    }
+    let tasks_info: Vec<TaskResources> = {
+        let rows = sqlx::query_as::<_, (Option<String>, Option<String>, Option<String>, String)>(
+            "SELECT agent_name, preview_slug, branch_name, repo FROM tasks WHERE id = ANY($1)",
+        )
+        .bind(&descendant_ids)
+        .fetch_all(&state.db)
+        .await?;
+        rows.into_iter()
+            .map(|(agent_name, preview_slug, branch_name, repo)| TaskResources {
+                agent_name,
+                preview_slug,
+                branch_name,
+                repo,
+            })
+            .collect()
+    };
+
+    // 4. Best-effort resource cleanup (log errors but continue)
+    let github_token = if delete_branch {
+        sqlx::query_scalar::<_, String>(
+            "SELECT github_token FROM users WHERE github_login = $1",
+        )
+        .bind(&admin.0.sub)
+        .fetch_optional(&state.db)
+        .await?
+    } else {
+        None
+    };
+
+    for task_res in &tasks_info {
+        if let Some(agent) = &task_res.agent_name {
+            if let Err(e) = shell::destroy_agent(&state.config, agent).await {
+                tracing::warn!("Failed to destroy agent {agent}: {e}");
+            }
+        }
+        if let Some(slug) = &task_res.preview_slug {
+            if let Err(e) = shell::destroy_preview(&state.config, slug).await {
+                tracing::warn!("Failed to destroy preview {slug}: {e}");
+            }
+        }
+        if delete_branch {
+            if let (Some(branch), Some(token)) = (&task_res.branch_name, &github_token) {
+                if let Err(e) =
+                    shell::delete_remote_branch(&task_res.repo, branch, token).await
+                {
+                    tracing::warn!("Failed to delete branch {branch}: {e}");
+                }
+            }
+        }
+    }
+
+    // 5. Delete DB records in FK-safe order within a transaction
+    let mut tx = state.db.begin().await?;
+    sqlx::query("DELETE FROM task_actions WHERE task_id = ANY($1)")
+        .bind(&descendant_ids)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM task_logs WHERE task_id = ANY($1)")
+        .bind(&descendant_ids)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM task_messages WHERE task_id = ANY($1)")
+        .bind(&descendant_ids)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM task_state_transitions WHERE task_id = ANY($1)")
+        .bind(&descendant_ids)
+        .execute(&mut *tx)
+        .await?;
+    // Delete children before parents to satisfy FK constraints
+    // Reverse the CTE order (children come after parents in BFS order)
+    let mut reversed_ids = descendant_ids.clone();
+    reversed_ids.reverse();
+    for task_id in &reversed_ids {
+        sqlx::query("DELETE FROM tasks WHERE id = $1")
+            .bind(task_id)
+            .execute(&mut *tx)
+            .await?;
+    }
+    tx.commit().await?;
+
+    // 6. Audit log
+    crate::audit::log_event(
+        &state.db,
+        "admin.task_deleted",
+        &admin.0.sub,
+        Some(&id),
+        serde_json::json!({
+            "deleted_count": descendant_ids.len(),
+            "delete_branch": delete_branch,
+        }),
+        None,
+    )
+    .await;
+
+    Ok(Json(serde_json::json!({ "ok": true })))
 }

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -3412,23 +3412,23 @@ pub async fn admin_delete_task(
         .fetch_all(&state.db)
         .await?;
         rows.into_iter()
-            .map(|(agent_name, preview_slug, branch_name, repo)| TaskResources {
-                agent_name,
-                preview_slug,
-                branch_name,
-                repo,
-            })
+            .map(
+                |(agent_name, preview_slug, branch_name, repo)| TaskResources {
+                    agent_name,
+                    preview_slug,
+                    branch_name,
+                    repo,
+                },
+            )
             .collect()
     };
 
     // 4. Best-effort resource cleanup (log errors but continue)
     let github_token = if delete_branch {
-        sqlx::query_scalar::<_, String>(
-            "SELECT github_token FROM users WHERE github_login = $1",
-        )
-        .bind(&admin.0.sub)
-        .fetch_optional(&state.db)
-        .await?
+        sqlx::query_scalar::<_, String>("SELECT github_token FROM users WHERE github_login = $1")
+            .bind(&admin.0.sub)
+            .fetch_optional(&state.db)
+            .await?
     } else {
         None
     };
@@ -3446,9 +3446,7 @@ pub async fn admin_delete_task(
         }
         if delete_branch {
             if let (Some(branch), Some(token)) = (&task_res.branch_name, &github_token) {
-                if let Err(e) =
-                    shell::delete_remote_branch(&task_res.repo, branch, token).await
-                {
+                if let Err(e) = shell::delete_remote_branch(&task_res.repo, branch, token).await {
                     tracing::warn!("Failed to delete branch {branch}: {e}");
                 }
             }

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -217,6 +217,15 @@ export const setUserRepos = (login: string, repos: string[]) =>
     method: 'PUT',
     body: JSON.stringify({ repos }),
   });
+export const adminDeleteTask = (id: string, deleteBranch?: boolean) =>
+  apiFetch<{ ok: boolean }>(`/api/admin/tasks/${id}`, {
+    method: 'DELETE',
+    body: JSON.stringify({ delete_branch: deleteBranch ?? false }),
+  });
+
+export const listOrphanedPreviews = () =>
+  apiFetch<Preview[]>('/api/admin/cleanup/orphaned-previews');
+
 export const listSecrets = (repo?: string) => {
   const qs = repo ? `?repo=${encodeURIComponent(repo)}` : '';
   return apiFetch<{ id: number; repo: string; name: string; created_by: string | null; created_at: string }[]>(

--- a/dashboard/frontend/src/pages/Admin.tsx
+++ b/dashboard/frontend/src/pages/Admin.tsx
@@ -21,7 +21,7 @@ import {
   listOrphanedPreviews,
   destroyPreview,
 } from '@/lib/api';
-import type { PolicyPreset, Task, Preview } from '@/lib/api';
+import type { PolicyPreset, Task } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/dashboard/frontend/src/pages/Admin.tsx
+++ b/dashboard/frontend/src/pages/Admin.tsx
@@ -16,8 +16,12 @@ import {
   deleteOrgPolicy,
   listPresets,
   getMe,
+  listTasks,
+  adminDeleteTask,
+  listOrphanedPreviews,
+  destroyPreview,
 } from '@/lib/api';
-import type { PolicyPreset } from '@/lib/api';
+import type { PolicyPreset, Task, Preview } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -31,8 +35,10 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
-import { Users, KeyRound, Shield, Building, Trash2, Plus, X, Settings } from 'lucide-react';
+import { Users, KeyRound, Shield, Building, Trash2, Plus, X, Settings, AlertTriangle } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
+import { statusVariant } from '@/lib/status';
+import { timeAgo } from '@/lib/utils';
 
 const ROLES = ['admin', 'member', 'viewer'] as const;
 
@@ -51,6 +57,7 @@ export default function Admin() {
       <SecretsSection queryClient={queryClient} />
       <PoliciesSection queryClient={queryClient} />
       <OrgPoliciesSection queryClient={queryClient} />
+      <CleanupSection queryClient={queryClient} />
     </div>
   );
 }
@@ -1207,5 +1214,236 @@ function OrgPoliciesSection({ queryClient }: { queryClient: ReturnType<typeof us
         </Dialog>
       </CardContent>
     </Card>
+  );
+}
+
+// ── Cleanup Section ──
+
+function CleanupSection({ queryClient }: { queryClient: ReturnType<typeof useQueryClient> }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <AlertTriangle className="size-5" />
+          Cleanup
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
+          <strong>Danger Zone</strong> — Deleting tasks and previews is permanent and cannot be undone. Running tasks will be force-stopped.
+        </div>
+        <TaskCleanupTable queryClient={queryClient} />
+        <OrphanedPreviewsTable queryClient={queryClient} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function TaskCleanupTable({ queryClient }: { queryClient: ReturnType<typeof useQueryClient> }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-tasks'],
+    queryFn: () => listTasks({ per_page: 200 }),
+  });
+
+  const [deleteTask, setDeleteTask] = useState<Task | null>(null);
+  const [deleteBranch, setDeleteBranch] = useState(false);
+
+  const deleteMutation = useMutation({
+    mutationFn: (opts: { id: string; deleteBranch: boolean }) =>
+      adminDeleteTask(opts.id, opts.deleteBranch),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-tasks'] });
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      setDeleteTask(null);
+      setDeleteBranch(false);
+    },
+  });
+
+  const tasks = data?.tasks ?? [];
+
+  return (
+    <div>
+      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">Tasks</h3>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      ) : tasks.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No tasks found.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase tracking-wider text-muted-foreground">
+                <th className="pb-2 pr-4 font-medium">Name / Prompt</th>
+                <th className="pb-2 pr-4 font-medium">Repo</th>
+                <th className="pb-2 pr-4 font-medium">Status</th>
+                <th className="pb-2 pr-4 font-medium">Created By</th>
+                <th className="pb-2 pr-4 font-medium">Created</th>
+                <th className="pb-2 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {tasks.map((task) => {
+                const sv = statusVariant(task.status);
+                return (
+                  <tr key={task.id} className="border-b border-border/50 hover:bg-secondary/40 transition-colors duration-100">
+                    <td className="py-2 pr-4 max-w-[300px] truncate">
+                      {task.name || task.prompt.slice(0, 60)}
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-xs">{task.repo}</td>
+                    <td className="py-2 pr-4">
+                      <Badge variant={sv.variant} className={sv.className}>
+                        {task.status}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4">{task.created_by ?? '—'}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">{timeAgo(task.created_at)}</td>
+                    <td className="py-2">
+                      <Button variant="ghost" size="sm" onClick={() => setDeleteTask(task)}>
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Delete Task Confirmation Dialog */}
+      <Dialog open={deleteTask !== null} onOpenChange={(open) => { if (!open) { setDeleteTask(null); setDeleteBranch(false); } }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Task</DialogTitle>
+            <DialogDescription>
+              This will permanently destroy the task, its agent container, preview, and all associated data (logs, messages, actions). This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteTask && (
+            <div className="space-y-3 text-sm">
+              <p><strong>Task:</strong> {deleteTask.name || deleteTask.prompt.slice(0, 80)}</p>
+              {deleteTask.agent_name && <p><strong>Agent:</strong> {deleteTask.agent_name} (will be destroyed)</p>}
+              {deleteTask.preview_slug && <p><strong>Preview:</strong> {deleteTask.preview_slug} (will be destroyed)</p>}
+              {deleteTask.branch_name && <p><strong>Branch:</strong> {deleteTask.branch_name}</p>}
+              {deleteTask.branch_name && (
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={deleteBranch}
+                    onChange={(e) => setDeleteBranch(e.target.checked)}
+                    className="rounded border-border"
+                  />
+                  <span>Also delete remote git branch</span>
+                </label>
+              )}
+            </div>
+          )}
+          {deleteMutation.isError && (
+            <p className="text-sm text-destructive">{(deleteMutation.error as Error).message}</p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setDeleteTask(null); setDeleteBranch(false); }}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteTask && deleteMutation.mutate({ id: deleteTask.id, deleteBranch })}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete permanently'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function OrphanedPreviewsTable({ queryClient }: { queryClient: ReturnType<typeof useQueryClient> }) {
+  const { data: previews, isLoading } = useQuery({
+    queryKey: ['admin-orphaned-previews'],
+    queryFn: listOrphanedPreviews,
+  });
+
+  const [deleteSlug, setDeleteSlug] = useState<string | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: (slug: string) => destroyPreview(slug),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-orphaned-previews'] });
+      queryClient.invalidateQueries({ queryKey: ['previews'] });
+      setDeleteSlug(null);
+    },
+  });
+
+  return (
+    <div>
+      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">Orphaned Previews</h3>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      ) : !previews || previews.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No orphaned previews found.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase tracking-wider text-muted-foreground">
+                <th className="pb-2 pr-4 font-medium">Slug</th>
+                <th className="pb-2 pr-4 font-medium">Repo</th>
+                <th className="pb-2 pr-4 font-medium">Branch</th>
+                <th className="pb-2 pr-4 font-medium">URL</th>
+                <th className="pb-2 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {previews.map((p) => (
+                <tr key={p.slug} className="border-b border-border/50 hover:bg-secondary/40 transition-colors duration-100">
+                  <td className="py-2 pr-4 font-mono text-xs">{p.slug}</td>
+                  <td className="py-2 pr-4 font-mono text-xs">{p.repo}</td>
+                  <td className="py-2 pr-4">{p.branch}</td>
+                  <td className="py-2 pr-4">
+                    <a href={p.url} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline dark:text-blue-400">
+                      {p.url}
+                    </a>
+                  </td>
+                  <td className="py-2">
+                    <Button variant="ghost" size="sm" onClick={() => setDeleteSlug(p.slug)}>
+                      <Trash2 className="size-4" />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Delete Orphaned Preview Confirmation Dialog */}
+      <Dialog open={deleteSlug !== null} onOpenChange={(open) => { if (!open) setDeleteSlug(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Orphaned Preview</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to destroy the preview &ldquo;{deleteSlug}&rdquo;? This will remove the container and cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteMutation.isError && (
+            <p className="text-sm text-destructive">{(deleteMutation.error as Error).message}</p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteSlug(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteSlug && deleteMutation.mutate(deleteSlug)}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Destroying...' : 'Destroy preview'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add admin endpoint to cascade-delete a task and all its descendants, including destroying associated agent containers, previews, and optionally remote git branches
- Add endpoint to list orphaned previews (containers with no corresponding task in the DB)
- Add Cleanup section to the Admin UI with task deletion (with confirmation dialog) and orphaned preview management

## Test plan
- [ ] Verify admin can delete a task and its subtasks are also removed
- [ ] Confirm agent containers and previews are destroyed on task deletion
- [ ] Test the "also delete remote branch" checkbox works correctly
- [ ] Verify orphaned previews are listed and can be individually destroyed
- [ ] Confirm non-admin users cannot access the cleanup endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)