### PR TITLE
Fix activity timestamps and add diff refresh button

### DIFF
--- a/dashboard/backend/src/cost.rs
+++ b/dashboard/backend/src/cost.rs
@@ -158,8 +158,8 @@ pub async fn list_budgets(
     let budgets = sqlx::query_as::<_, Budget>(
         "SELECT id, scope, scope_type, monthly_limit_usd, alert_threshold_pct, \
          created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at \
          FROM budgets ORDER BY scope_type, scope",
     )
     .fetch_all(&state.db)
@@ -201,8 +201,8 @@ pub async fn create_budget(
     let budget = sqlx::query_as::<_, Budget>(
         "SELECT id, scope, scope_type, monthly_limit_usd, alert_threshold_pct, \
          created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at \
          FROM budgets WHERE scope = $1 AND scope_type = $2",
     )
     .bind(&req.scope)
@@ -254,8 +254,8 @@ pub async fn update_budget(
         "UPDATE budgets SET {} WHERE id = $1 \
          RETURNING id, scope, scope_type, monthly_limit_usd, alert_threshold_pct, \
          created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at",
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at",
         sets.join(", ")
     );
 
@@ -379,8 +379,8 @@ async fn load_budget(
     let budget = sqlx::query_as::<_, Budget>(
         "SELECT id, scope, scope_type, monthly_limit_usd, alert_threshold_pct, \
          created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at \
          FROM budgets WHERE scope = $1 AND scope_type = $2",
     )
     .bind(scope)

--- a/dashboard/backend/src/policies.rs
+++ b/dashboard/backend/src/policies.rs
@@ -152,8 +152,8 @@ pub async fn list_policies(
     let policies = sqlx::query_as::<_, RepoPolicy>(
         "SELECT id, repo, protected_branches, allowed_tools, network_egress, \
          max_cost_usd, require_approval_above_usd, created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at \
          FROM repo_policies ORDER BY repo",
     )
     .fetch_all(&state.db)
@@ -197,8 +197,8 @@ pub async fn create_policy(
     let policy = sqlx::query_as::<_, RepoPolicy>(
         "SELECT id, repo, protected_branches, allowed_tools, network_egress, \
          max_cost_usd, require_approval_above_usd, created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at \
          FROM repo_policies WHERE repo = $1",
     )
     .bind(&req.repo)
@@ -262,8 +262,8 @@ pub async fn update_policy(
         "UPDATE repo_policies SET {} WHERE id = $1 \
          RETURNING id, repo, protected_branches, allowed_tools, network_egress, \
          max_cost_usd, require_approval_above_usd, created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at",
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at",
         sets.join(", ")
     );
 
@@ -345,8 +345,8 @@ pub async fn delete_policy(
 
 const ORG_POLICY_COLUMNS: &str = "id, org, protected_branches, allowed_tools, network_egress, \
      max_cost_usd, require_approval_above_usd, created_by, \
-     TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-     TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at";
+     TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+     TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at";
 
 /// GET /api/admin/org-policies
 pub async fn list_org_policies(
@@ -540,8 +540,8 @@ pub async fn load_policy_for_repo(db: &PgPool, repo: &str) -> Result<Option<Repo
     let policy = sqlx::query_as::<_, RepoPolicy>(
         "SELECT id, repo, protected_branches, allowed_tools, network_egress, \
          max_cost_usd, require_approval_above_usd, created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at \
          FROM repo_policies WHERE repo = $1",
     )
     .bind(repo)

--- a/dashboard/backend/src/secrets.rs
+++ b/dashboard/backend/src/secrets.rs
@@ -79,7 +79,7 @@ pub async fn list_secrets(
     let secrets = if let Some(ref repo) = params.repo {
         sqlx::query_as::<_, SecretEntry>(
             "SELECT id, repo, name, created_by, \
-             TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at \
+             TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at \
              FROM secrets WHERE repo = $1 ORDER BY repo, name",
         )
         .bind(repo)
@@ -88,7 +88,7 @@ pub async fn list_secrets(
     } else {
         sqlx::query_as::<_, SecretEntry>(
             "SELECT id, repo, name, created_by, \
-             TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at \
+             TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at \
              FROM secrets ORDER BY repo, name",
         )
         .fetch_all(&state.db)
@@ -128,7 +128,7 @@ pub async fn create_secret(
 
     let entry = sqlx::query_as::<_, SecretEntry>(
         "SELECT id, repo, name, created_by, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at \
          FROM secrets WHERE repo = $1 AND name = $2",
     )
     .bind(&req.repo)

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -230,8 +230,8 @@ pub async fn list_tasks(
     let data_sql = format!(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks {where_clause} ORDER BY created_at DESC LIMIT ${bind_idx} OFFSET ${next_idx}",
@@ -262,8 +262,8 @@ pub async fn get_task(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -291,8 +291,8 @@ pub async fn get_subtasks(
     let subtasks = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE parent_task_id = $1 ORDER BY created_at ASC"
@@ -386,8 +386,8 @@ pub async fn create_task(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -1410,7 +1410,7 @@ async fn follow_up_loop(
         // Filter out claude's own messages so we only process user messages
         let new_messages: Vec<TaskMessage> = sqlx::query_as::<_, TaskMessage>(
             "SELECT id, task_id, sender, content, \
-             TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, image_url \
+             TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, image_url \
              FROM task_messages \
              WHERE task_id = $1 AND id > $2 AND sender NOT IN ('claude', 'system') \
              ORDER BY id ASC",
@@ -2094,7 +2094,7 @@ pub async fn list_messages(
         let limit = params.limit.unwrap_or(100);
         sqlx::query_as::<_, TaskMessage>(
             "SELECT id, task_id, sender, content, \
-             TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, image_url \
+             TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, image_url \
              FROM task_messages WHERE task_id = $1 AND id < $2 \
              ORDER BY created_at ASC LIMIT $3",
         )
@@ -2106,7 +2106,7 @@ pub async fn list_messages(
     } else if let Some(limit) = params.limit {
         sqlx::query_as::<_, TaskMessage>(
             "SELECT id, task_id, sender, content, \
-             TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, image_url \
+             TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, image_url \
              FROM task_messages WHERE task_id = $1 \
              ORDER BY created_at ASC LIMIT $2",
         )
@@ -2117,7 +2117,7 @@ pub async fn list_messages(
     } else {
         sqlx::query_as::<_, TaskMessage>(
             "SELECT id, task_id, sender, content, \
-             TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, image_url \
+             TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, image_url \
              FROM task_messages WHERE task_id = $1 \
              ORDER BY created_at ASC",
         )
@@ -2173,7 +2173,7 @@ pub async fn send_message(
 
     let message = sqlx::query_as::<_, TaskMessage>(
         "SELECT id, task_id, sender, content, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, image_url \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, image_url \
          FROM task_messages WHERE task_id = $1 ORDER BY id DESC LIMIT 1",
     )
     .bind(&id)
@@ -2335,8 +2335,8 @@ pub async fn reopen_task(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -2430,8 +2430,8 @@ pub async fn reopen_task(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -2452,8 +2452,8 @@ pub async fn get_task_diff(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1",
@@ -2496,8 +2496,8 @@ pub async fn update_task_name(
     let _ = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -2527,8 +2527,8 @@ pub async fn update_task_name(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -2807,8 +2807,8 @@ pub async fn recover_interrupted_tasks(
     let tasks = match sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE status NOT IN ('completed', 'failed')",
@@ -3062,7 +3062,7 @@ async fn generate_pr_body(
     // 1. Fetch conversation messages
     let messages = sqlx::query_as::<_, TaskMessage>(
         "SELECT id, task_id, sender, content, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, image_url \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, image_url \
          FROM task_messages WHERE task_id = $1 ORDER BY id",
     )
     .bind(&task.id)
@@ -3193,8 +3193,8 @@ pub async fn create_pr(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -3294,8 +3294,8 @@ pub async fn create_pr(
     let updated_task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -3338,8 +3338,8 @@ pub async fn link_pr(
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at, \
-         TO_CHAR(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at, \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at, \
+         TO_CHAR(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at, \
          parent_task_id, created_by, screenshot_url, image_url, \
          total_input_tokens, total_output_tokens, total_cost_usd, name, pr_url, pr_number, compute_seconds \
          FROM tasks WHERE id = $1"
@@ -3359,7 +3359,7 @@ pub async fn get_task_logs(
 ) -> Result<Json<Vec<TaskLog>>, AppError> {
     check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
     let logs = sqlx::query_as::<_, TaskLog>(
-        "SELECT id, task_id, TO_CHAR(timestamp, 'YYYY-MM-DD HH24:MI:SS') as timestamp, line \
+        "SELECT id, task_id, TO_CHAR(timestamp, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as timestamp, line \
          FROM task_logs WHERE task_id = $1 ORDER BY id ASC",
     )
     .bind(&id)

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -2204,7 +2204,7 @@ pub async fn list_actions(
     check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
     let actions = sqlx::query_as::<_, TaskAction>(
         "SELECT id, task_id, action_type, tool_name, tool_input, summary, \
-         TO_CHAR(created_at, 'YYYY-MM-DD HH24:MI:SS') as created_at \
+         TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at \
          FROM task_actions WHERE task_id = $1 ORDER BY id ASC",
     )
     .bind(&id)

--- a/dashboard/backend/src/ws.rs
+++ b/dashboard/backend/src/ws.rs
@@ -103,7 +103,7 @@ pub async fn task_output_ws(
 async fn handle_task_output(mut socket: WebSocket, state: AppState, task_id: String) {
     // First send any existing logs from the DB
     if let Ok(logs) = sqlx::query_as::<_, crate::models::TaskLog>(
-        "SELECT id, task_id, TO_CHAR(timestamp, 'YYYY-MM-DD HH24:MI:SS') as timestamp, line \
+        "SELECT id, task_id, TO_CHAR(timestamp, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as timestamp, line \
          FROM task_logs WHERE task_id = $1 ORDER BY id ASC",
     )
     .bind(&task_id)

--- a/dashboard/frontend/e2e/task-detail.spec.ts
+++ b/dashboard/frontend/e2e/task-detail.spec.ts
@@ -62,9 +62,10 @@ test.describe('Task Detail', () => {
     await expect(adminPage.getByText('Container Logs')).toBeVisible();
   });
 
-  test('shows Diff tab for task with branch', async ({ adminPage }) => {
+  test('shows Diff tab with refresh button', async ({ adminPage }) => {
     await adminPage.goto(`/tasks/${TEST_IDS.tasks.completed}`);
-    await expect(adminPage.getByRole('tab', { name: 'Diff' })).toBeVisible();
+    await adminPage.getByRole('tab', { name: 'Diff' }).click();
+    await expect(adminPage.getByRole('button', { name: 'Refresh' })).toBeVisible();
   });
 
   test('shows error message for failed task', async ({ adminPage }) => {

--- a/dashboard/frontend/src/pages/TaskDetail.tsx
+++ b/dashboard/frontend/src/pages/TaskDetail.tsx
@@ -334,21 +334,19 @@ export default function TaskDetail() {
 
         {/* Diff tab */}
         <TabsContent value="diff" className="flex-1 flex flex-col min-h-0 rounded-b-lg border border-t-0 border-border bg-card overflow-hidden">
+          <div className="flex items-center justify-end px-4 py-2 border-b border-border bg-card/50">
+            <button
+              onClick={() => queryClient.invalidateQueries({ queryKey: ['task-diff', id] })}
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <RotateCcw className="size-3.5" />
+              Refresh
+            </button>
+          </div>
           {diffData?.diff ? (
-            <>
-              <div className="flex items-center justify-end px-4 py-2 border-b border-border bg-card/50">
-                <button
-                  onClick={() => queryClient.invalidateQueries({ queryKey: ['task-diff', id] })}
-                  className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <RotateCcw className="size-3.5" />
-                  Refresh
-                </button>
-              </div>
-              <div className="flex-1 overflow-y-auto">
-                <DiffViewer diff={diffData.diff} />
-              </div>
-            </>
+            <div className="flex-1 overflow-y-auto">
+              <DiffViewer diff={diffData.diff} />
+            </div>
           ) : (
             <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
               <FileDiff className="size-8 mb-2 opacity-30" />

--- a/dashboard/frontend/src/pages/TaskDetail.tsx
+++ b/dashboard/frontend/src/pages/TaskDetail.tsx
@@ -333,9 +333,22 @@ export default function TaskDetail() {
         </TabsContent>
 
         {/* Diff tab */}
-        <TabsContent value="diff" className="flex-1 overflow-y-auto rounded-b-lg border border-t-0 border-border bg-card">
+        <TabsContent value="diff" className="flex-1 flex flex-col min-h-0 rounded-b-lg border border-t-0 border-border bg-card overflow-hidden">
           {diffData?.diff ? (
-            <DiffViewer diff={diffData.diff} />
+            <>
+              <div className="flex items-center justify-end px-4 py-2 border-b border-border bg-card/50">
+                <button
+                  onClick={() => queryClient.invalidateQueries({ queryKey: ['task-diff', id] })}
+                  className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <RotateCcw className="size-3.5" />
+                  Refresh
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto">
+                <DiffViewer diff={diffData.diff} />
+              </div>
+            </>
           ) : (
             <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
               <FileDiff className="size-8 mb-2 opacity-30" />


### PR DESCRIPTION
## Summary
- Fix `TO_CHAR` format for task action timestamps to use ISO 8601 (`...T...Z`) so browsers parse them correctly — was causing all timestamps to show "Just Now"
- Add a Refresh button to the diff tab for manual re-fetch

Closes #157

## Test plan
- [ ] Verify activity timeline shows correct relative timestamps (e.g. "5m ago", "2h ago")
- [ ] Verify diff Refresh button re-fetches the diff