### PR TITLE
Fix preview cache, state persistence, and loading feedback

### DIFF
--- a/dashboard/frontend/e2e/task-detail.spec.ts
+++ b/dashboard/frontend/e2e/task-detail.spec.ts
@@ -149,4 +149,10 @@ test.describe('Task Detail', () => {
     await adminPage.goto(`/tasks/${TEST_IDS.tasks.awaiting}`);
     await expect(adminPage.getByRole('tab', { name: 'Preview' })).toBeVisible();
   });
+
+  test('preview tab has refresh button', async ({ adminPage }) => {
+    await adminPage.goto(`/tasks/${TEST_IDS.tasks.awaiting}`);
+    await adminPage.getByRole('tab', { name: 'Preview' }).click();
+    await expect(adminPage.getByRole('button', { name: 'Refresh' })).toBeVisible();
+  });
 });

--- a/dashboard/frontend/e2e/task-detail.spec.ts
+++ b/dashboard/frontend/e2e/task-detail.spec.ts
@@ -150,9 +150,12 @@ test.describe('Task Detail', () => {
     await expect(adminPage.getByRole('tab', { name: 'Preview' })).toBeVisible();
   });
 
-  test('preview tab has refresh button', async ({ adminPage }) => {
+  test('preview tab refresh button works', async ({ adminPage }) => {
     await adminPage.goto(`/tasks/${TEST_IDS.tasks.awaiting}`);
     await adminPage.getByRole('tab', { name: 'Preview' }).click();
-    await expect(adminPage.getByRole('button', { name: 'Refresh' })).toBeVisible();
+    const refreshBtn = adminPage.getByRole('button', { name: 'Refresh' });
+    await expect(refreshBtn).toBeVisible();
+    await refreshBtn.click();
+    await expect(refreshBtn).toBeVisible();
   });
 });

--- a/dashboard/frontend/src/pages/Previews.tsx
+++ b/dashboard/frontend/src/pages/Previews.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
 import { listPreviews, createPreview, destroyPreview, ApiError } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -156,6 +157,7 @@ export default function Previews() {
                 </div>
               </div>
               <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending && <Loader2 className="size-4 animate-spin mr-2" />}
                 {createMutation.isPending ? 'Creating...' : 'Create'}
               </Button>
               {createMutation.isError && (

--- a/dashboard/frontend/src/pages/TaskDetail.tsx
+++ b/dashboard/frontend/src/pages/TaskDetail.tsx
@@ -56,6 +56,7 @@ export default function TaskDetail() {
   const navigate = useNavigate();
   const [connected, setConnected] = useState(false);
   const [showActivity, setShowActivity] = useState(false);
+  const [previewKey, setPreviewKey] = useState(0);
 
   const { data: task } = useQuery({
     queryKey: ['task', id],
@@ -346,22 +347,32 @@ export default function TaskDetail() {
           )}
         </TabsContent>
 
-        {/* Preview tab — embedded iframe of the deployed preview */}
+        {/* Preview tab — forceMount keeps iframe alive across tab switches to preserve navigation state */}
         {task?.preview_url && (
-          <TabsContent value="preview" className="flex-1 flex flex-col min-h-0 rounded-b-lg border border-t-0 border-border bg-card overflow-hidden">
+          <TabsContent value="preview" forceMount className="flex-1 flex flex-col min-h-0 rounded-b-lg border border-t-0 border-border bg-card overflow-hidden data-[state=inactive]:hidden">
             <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-card/50">
               <span className="text-sm text-muted-foreground truncate">{task.preview_url}</span>
-              <a
-                href={task.preview_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:underline shrink-0 ml-3"
-              >
-                <ExternalLink className="size-3.5" />
-                Open in new tab
-              </a>
+              <div className="flex items-center gap-3 shrink-0 ml-3">
+                <button
+                  onClick={() => setPreviewKey(k => k + 1)}
+                  className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <RotateCcw className="size-3.5" />
+                  Refresh
+                </button>
+                <a
+                  href={task.preview_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  <ExternalLink className="size-3.5" />
+                  Open in new tab
+                </a>
+              </div>
             </div>
             <iframe
+              key={previewKey}
               src={task.preview_url}
               className="flex-1 w-full border-0"
               title="Preview"


### PR DESCRIPTION
## Summary
- Add Refresh button to preview iframe that busts cache by remounting via React key
- Keep preview iframe mounted across tab switches (`forceMount`) so in-app navigation state is preserved
- Add spinner to "Creating..." button on Previews page for better loading feedback

Closes #156

## Test plan
- [ ] Verify Refresh button reloads the preview iframe
- [ ] Verify switching away from Preview tab and back preserves navigation state within the iframe
- [ ] Verify Creating button shows spinner while preview is being created