### PR TITLE
Allow members to see tasks from repos they have access to

### DIFF
--- a/dashboard/backend/src/auth.rs
+++ b/dashboard/backend/src/auth.rs
@@ -334,25 +334,46 @@ pub async fn check_repo_permission(
     )))
 }
 
-/// Check if a user owns a task (or is an admin).
+/// Check if a user can access a task.
+/// Access is granted if the user is an admin, created the task, or has
+/// permission to the task's repo (via org membership or explicit grant).
 pub async fn check_task_ownership(
     db: &PgPool,
     task_id: &str,
     github_login: &str,
     role: &str,
+    github_org: &str,
 ) -> Result<(), AppError> {
     if role == "admin" {
         return Ok(());
     }
 
-    let created_by: Option<String> =
-        sqlx::query_scalar("SELECT created_by FROM tasks WHERE id = $1")
-            .bind(task_id)
-            .fetch_optional(db)
-            .await?
-            .flatten();
+    let row: Option<(String, String)> = sqlx::query_as(
+        "SELECT created_by, repo FROM tasks WHERE id = $1",
+    )
+    .bind(task_id)
+    .fetch_optional(db)
+    .await?;
 
-    if created_by.as_deref() == Some(github_login) {
+    let (created_by, repo) = match row {
+        Some(r) => r,
+        None => {
+            return Err(AppError::Forbidden(
+                "You do not have permission to access this task".into(),
+            ));
+        }
+    };
+
+    // Allow if user created the task
+    if created_by == github_login {
+        return Ok(());
+    }
+
+    // Allow if user has access to the task's repo
+    if check_repo_permission(db, github_login, &repo, role, github_org)
+        .await
+        .is_ok()
+    {
         return Ok(());
     }
 

--- a/dashboard/backend/src/auth.rs
+++ b/dashboard/backend/src/auth.rs
@@ -348,12 +348,11 @@ pub async fn check_task_ownership(
         return Ok(());
     }
 
-    let row: Option<(String, String)> = sqlx::query_as(
-        "SELECT created_by, repo FROM tasks WHERE id = $1",
-    )
-    .bind(task_id)
-    .fetch_optional(db)
-    .await?;
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT created_by, repo FROM tasks WHERE id = $1")
+            .bind(task_id)
+            .fetch_optional(db)
+            .await?;
 
     let (created_by, repo) = match row {
         Some(r) => r,

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -280,7 +280,14 @@ pub async fn get_task(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
@@ -302,7 +309,14 @@ pub async fn get_subtasks(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<Task>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
 
     // Verify parent exists
     let _ = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tasks WHERE id = $1")
@@ -2110,7 +2124,14 @@ pub async fn list_messages(
     Path(id): Path<String>,
     Query(params): Query<ListMessagesQuery>,
 ) -> Result<Json<Vec<TaskMessage>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
 
     let messages = if let Some(before_id) = params.before_id {
         let limit = params.limit.unwrap_or(100);
@@ -2157,7 +2178,14 @@ pub async fn send_message(
     Path(id): Path<String>,
     Json(req): Json<SendMessageRequest>,
 ) -> Result<Json<TaskMessage>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
 
     // Verify task exists
     let task_exists = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tasks WHERE id = $1")
@@ -2223,7 +2251,14 @@ pub async fn list_actions(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<TaskAction>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
     let actions = sqlx::query_as::<_, TaskAction>(
         "SELECT id, task_id, action_type, tool_name, tool_input, summary, \
          TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at \
@@ -2352,7 +2387,14 @@ pub async fn reopen_task(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
 
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
@@ -2469,7 +2511,14 @@ pub async fn get_task_diff(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
 
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
@@ -2514,7 +2563,14 @@ pub async fn update_task_name(
     Path(id): Path<String>,
     Json(req): Json<UpdateTaskNameRequest>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
     let _ = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
@@ -3210,7 +3266,14 @@ pub async fn create_pr(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
 
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
@@ -3340,7 +3403,14 @@ pub async fn link_pr(
     Path(id): Path<String>,
     Json(req): Json<crate::models::LinkPrRequest>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
     // Extract PR number from URL (e.g. https://github.com/owner/repo/pull/123)
     let pr_number: Option<i32> = req.pr_url.rsplit('/').next().and_then(|s| s.parse().ok());
 
@@ -3384,7 +3454,14 @@ pub async fn get_task_logs(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<TaskLog>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
+    check_task_ownership(
+        &state.db,
+        &id,
+        &user.0.sub,
+        &user.0.role,
+        &state.config.github_org,
+    )
+    .await?;
     let logs = sqlx::query_as::<_, TaskLog>(
         "SELECT id, task_id, TO_CHAR(timestamp, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as timestamp, line \
          FROM task_logs WHERE task_id = $1 ORDER BY id ASC",

--- a/dashboard/backend/src/tasks.rs
+++ b/dashboard/backend/src/tasks.rs
@@ -35,8 +35,9 @@ async fn check_task_ownership(
     task_id: &str,
     github_login: &str,
     role: &str,
+    github_org: &str,
 ) -> Result<(), AppError> {
-    auth::check_task_ownership(db, task_id, github_login, role).await
+    auth::check_task_ownership(db, task_id, github_login, role, github_org).await
 }
 
 /// Shared context threaded through the pipeline functions.
@@ -184,11 +185,32 @@ pub async fn list_tasks(
     // We'll collect bind values as strings for the dynamic query
     let mut bind_values: Vec<String> = Vec::new();
 
-    // Non-admin users only see their own tasks
+    // Non-admin users see tasks they created OR tasks from repos they have access to
     if user.0.role != "admin" {
-        conditions.push(format!("created_by = ${bind_idx}"));
-        bind_values.push(user.0.sub.clone());
-        bind_idx += 1;
+        let org_prefix = format!("{}/%", state.config.github_org);
+        if user.0.role == "member" {
+            // Members can see tasks from any repo in the org, plus repos explicitly granted
+            conditions.push(format!(
+                "(created_by = ${bind_idx} OR repo LIKE ${} OR repo IN \
+                 (SELECT repo FROM user_repo_permissions WHERE github_login = ${}))",
+                bind_idx + 1,
+                bind_idx + 2,
+            ));
+            bind_values.push(user.0.sub.clone());
+            bind_values.push(org_prefix);
+            bind_values.push(user.0.sub.clone());
+            bind_idx += 3;
+        } else {
+            // Viewers only see tasks from repos explicitly granted
+            conditions.push(format!(
+                "(created_by = ${bind_idx} OR repo IN \
+                 (SELECT repo FROM user_repo_permissions WHERE github_login = ${}))",
+                bind_idx + 1,
+            ));
+            bind_values.push(user.0.sub.clone());
+            bind_values.push(user.0.sub.clone());
+            bind_idx += 2;
+        }
     }
 
     if let Some(ref status) = params.status {
@@ -258,7 +280,7 @@ pub async fn get_task(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
@@ -280,7 +302,7 @@ pub async fn get_subtasks(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<Task>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
 
     // Verify parent exists
     let _ = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tasks WHERE id = $1")
@@ -2088,7 +2110,7 @@ pub async fn list_messages(
     Path(id): Path<String>,
     Query(params): Query<ListMessagesQuery>,
 ) -> Result<Json<Vec<TaskMessage>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
 
     let messages = if let Some(before_id) = params.before_id {
         let limit = params.limit.unwrap_or(100);
@@ -2135,7 +2157,7 @@ pub async fn send_message(
     Path(id): Path<String>,
     Json(req): Json<SendMessageRequest>,
 ) -> Result<Json<TaskMessage>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
 
     // Verify task exists
     let task_exists = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tasks WHERE id = $1")
@@ -2201,7 +2223,7 @@ pub async fn list_actions(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<TaskAction>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
     let actions = sqlx::query_as::<_, TaskAction>(
         "SELECT id, task_id, action_type, tool_name, tool_input, summary, \
          TO_CHAR(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at \
@@ -2330,7 +2352,7 @@ pub async fn reopen_task(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
 
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
@@ -2447,7 +2469,7 @@ pub async fn get_task_diff(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
 
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
@@ -2492,7 +2514,7 @@ pub async fn update_task_name(
     Path(id): Path<String>,
     Json(req): Json<UpdateTaskNameRequest>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
     let _ = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
          preview_slug, preview_url, error_message, \
@@ -3188,7 +3210,7 @@ pub async fn create_pr(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
 
     let task = sqlx::query_as::<_, Task>(
         "SELECT id, prompt, repo, base_branch, branch_name, agent_name, status, \
@@ -3318,7 +3340,7 @@ pub async fn link_pr(
     Path(id): Path<String>,
     Json(req): Json<crate::models::LinkPrRequest>,
 ) -> Result<Json<Task>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
     // Extract PR number from URL (e.g. https://github.com/owner/repo/pull/123)
     let pr_number: Option<i32> = req.pr_url.rsplit('/').next().and_then(|s| s.parse().ok());
 
@@ -3362,7 +3384,7 @@ pub async fn get_task_logs(
     State(state): State<crate::AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<TaskLog>>, AppError> {
-    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role).await?;
+    check_task_ownership(&state.db, &id, &user.0.sub, &user.0.role, &state.config.github_org).await?;
     let logs = sqlx::query_as::<_, TaskLog>(
         "SELECT id, task_id, TO_CHAR(timestamp, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as timestamp, line \
          FROM task_logs WHERE task_id = $1 ORDER BY id ASC",

--- a/dashboard/frontend/src/components/TaskChat.tsx
+++ b/dashboard/frontend/src/components/TaskChat.tsx
@@ -164,7 +164,9 @@ export default function TaskChat({ taskId, currentUserEmail, taskStatus }: TaskC
               className={`w-full rounded-md border-l-2 pl-4 py-3 pr-3 ${
                 msg.sender === currentUserEmail
                   ? 'border-l-blue-500 bg-blue-500/5'
-                  : 'border-l-amber-500 bg-amber-500/5'
+                  : msg.sender === 'claude'
+                    ? 'border-l-amber-500 bg-amber-500/5'
+                    : 'border-l-violet-500 bg-violet-500/5'
               }`}
             >
               <div className="flex items-center gap-2 mb-1.5">
@@ -172,7 +174,9 @@ export default function TaskChat({ taskId, currentUserEmail, taskStatus }: TaskC
                   className={`font-semibold text-xs ${
                     msg.sender === currentUserEmail
                       ? 'text-blue-700 dark:text-blue-400'
-                      : 'text-amber-700 dark:text-amber-400'
+                      : msg.sender === 'claude'
+                        ? 'text-amber-700 dark:text-amber-400'
+                        : 'text-violet-700 dark:text-violet-400'
                   }`}
                 >
                   {msg.sender === currentUserEmail ? 'You' : msg.sender === 'claude' ? 'Claude' : msg.sender}


### PR DESCRIPTION
## Summary
- Members could only see tasks they personally created, even if they had access to the repo
- Now `check_task_ownership` also checks repo permissions — if a user has access to the task's repo (via org membership or explicit grant), they can view the task
- Task list also updated to show tasks from accessible repos, not just tasks the user created
- Affects all task endpoints: detail, conversations, logs, diff, actions, PR creation, reopen

## Test plan
- [ ] As admin, grant a member access to a repo in Settings
- [ ] As that member, verify they can see tasks from that repo created by other users
- [ ] Verify they can view conversations, logs, diff, and other task data
- [ ] Verify admins still see everything
- [ ] Verify viewers only see tasks from repos explicitly granted to them