### PR TITLE
Add Product Health KPI dashboard (#73)

### DIFF
--- a/dashboard/backend/src/main.rs
+++ b/dashboard/backend/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod cost;
 mod db;
 mod error;
+mod metrics;
 mod models;
 mod policies;
 mod previews;
@@ -131,6 +132,8 @@ async fn main() -> anyhow::Result<()> {
         )
         // Admin: Audit Log
         .route("/admin/audit-log", get(audit::list_audit_log))
+        // Admin: Product health KPIs
+        .route("/admin/metrics/kpis", get(metrics::get_kpis))
         // Settings
         .route("/settings/ai", get(settings::get_ai_settings))
         .route("/settings/ai", put(settings::put_ai_settings))

--- a/dashboard/backend/src/metrics.rs
+++ b/dashboard/backend/src/metrics.rs
@@ -1,0 +1,122 @@
+use axum::extract::{Query, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::AdminUser;
+use crate::error::AppError;
+
+const WEEKLY_ACTIVE_WINDOW_DAYS: i32 = 7;
+const DEFAULT_WINDOW_DAYS: i32 = 30;
+
+#[derive(Debug, Deserialize)]
+pub struct KpiQuery {
+    pub days: Option<i32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct KpiTrendPoint {
+    pub day: String,
+    pub sessions: i64,
+    pub tasks_with_pr: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct KpiResponse {
+    pub window_days: i32,
+    pub weekly_active_prompting_users: i64,
+    pub sessions: i64,
+    pub tasks_with_pr: i64,
+    pub session_to_pr_conversion_rate: f64,
+    pub median_time_to_first_pr_seconds: Option<f64>,
+    pub trends: Vec<KpiTrendPoint>,
+}
+
+/// GET /api/admin/metrics/kpis?days={n}
+///
+/// Adoption and impact KPIs (tekton issue #73):
+/// - Weekly active prompting users: distinct users creating tasks in the last 7 days.
+/// - Session-to-PR conversion: share of tasks in the window whose task.pr_created
+///   event fired (a reviewable PR was opened). Merge-status tracking is a follow-up.
+/// - Median time-to-first-reviewable-PR: median seconds between task creation and
+///   the first `task.pr_created` audit event for that task.
+pub async fn get_kpis(
+    _admin: AdminUser,
+    State(state): State<crate::AppState>,
+    Query(q): Query<KpiQuery>,
+) -> Result<Json<KpiResponse>, AppError> {
+    let window_days = q.days.unwrap_or(DEFAULT_WINDOW_DAYS).max(1);
+
+    let weekly_active_prompting_users: i64 = sqlx::query_scalar(
+        "SELECT COUNT(DISTINCT created_by) \
+         FROM tasks \
+         WHERE created_by IS NOT NULL \
+           AND created_at >= NOW() - ($1 || ' days')::INTERVAL",
+    )
+    .bind(WEEKLY_ACTIVE_WINDOW_DAYS.to_string())
+    .fetch_one(&state.db)
+    .await?;
+
+    let (sessions, tasks_with_pr): (i64, i64) = sqlx::query_as(
+        "SELECT \
+            COUNT(*)::BIGINT, \
+            COUNT(*) FILTER (WHERE pr_url IS NOT NULL)::BIGINT \
+         FROM tasks \
+         WHERE created_at >= NOW() - ($1 || ' days')::INTERVAL",
+    )
+    .bind(window_days.to_string())
+    .fetch_one(&state.db)
+    .await?;
+
+    let session_to_pr_conversion_rate = if sessions > 0 {
+        tasks_with_pr as f64 / sessions as f64
+    } else {
+        0.0
+    };
+
+    let median_time_to_first_pr_seconds: Option<f64> = sqlx::query_scalar(
+        "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY diff_seconds) \
+         FROM ( \
+             SELECT EXTRACT(EPOCH FROM (MIN(a.created_at) - t.created_at))::DOUBLE PRECISION \
+                    AS diff_seconds \
+             FROM audit_log a \
+             JOIN tasks t ON t.id = a.target \
+             WHERE a.event_type = 'task.pr_created' \
+               AND t.created_at >= NOW() - ($1 || ' days')::INTERVAL \
+             GROUP BY t.id, t.created_at \
+         ) sub",
+    )
+    .bind(window_days.to_string())
+    .fetch_one(&state.db)
+    .await?;
+
+    let trends = sqlx::query_as::<_, (String, i64, i64)>(
+        "SELECT \
+            TO_CHAR(created_at::date, 'YYYY-MM-DD') AS day, \
+            COUNT(*)::BIGINT AS sessions, \
+            COUNT(*) FILTER (WHERE pr_url IS NOT NULL)::BIGINT AS tasks_with_pr \
+         FROM tasks \
+         WHERE created_at >= NOW() - ($1 || ' days')::INTERVAL \
+         GROUP BY created_at::date \
+         ORDER BY day",
+    )
+    .bind(window_days.to_string())
+    .fetch_all(&state.db)
+    .await?
+    .into_iter()
+    .map(|(day, sessions, tasks_with_pr)| KpiTrendPoint {
+        day,
+        sessions,
+        tasks_with_pr,
+    })
+    .collect();
+
+    Ok(Json(KpiResponse {
+        window_days,
+        weekly_active_prompting_users,
+        sessions,
+        tasks_with_pr,
+        session_to_pr_conversion_rate,
+        median_time_to_first_pr_seconds,
+        trends,
+    }))
+}

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Settings from './pages/Settings';
 import Webhooks from './pages/Webhooks';
 import CostDashboard from './pages/CostDashboard';
 import AuditLog from './pages/AuditLog';
+import KPIDashboard from './pages/KPIDashboard';
 
 export default function App() {
   return (
@@ -22,6 +23,7 @@ export default function App() {
         <Route path="/tasks/:id" element={<TaskDetail />} />
         <Route path="/admin" element={<Admin />} />
         <Route path="/cost" element={<CostDashboard />} />
+        <Route path="/kpis" element={<KPIDashboard />} />
         <Route path="/audit" element={<AuditLog />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/webhooks" element={<Webhooks />} />

--- a/dashboard/frontend/src/components/Layout.tsx
+++ b/dashboard/frontend/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getMe, logout, listTasks } from '@/lib/api';
-import { LayoutDashboard, Container, BrainCircuit, LogOut, Shield, SlidersHorizontal, DollarSign, ScrollText, Sun, Moon, Webhook } from 'lucide-react';
+import { LayoutDashboard, Container, BrainCircuit, LogOut, Shield, SlidersHorizontal, DollarSign, ScrollText, Sun, Moon, Webhook, TrendingUp } from 'lucide-react';
 import { useTheme } from '@/hooks/use-theme';
 import { Toaster, toast } from 'sonner';
 import CommandPalette from '@/components/CommandPalette';
@@ -249,6 +249,18 @@ export default function Layout() {
                     <SidebarMenuItem>
                       <SidebarMenuButton
                         asChild
+                        isActive={isActive('/kpis')}
+                        tooltip="Product Health"
+                      >
+                        <Link to="/kpis">
+                          <TrendingUp />
+                          <span>Product Health</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        asChild
                         isActive={isActive('/audit')}
                         tooltip="Audit Log"
                       >
@@ -305,7 +317,7 @@ export default function Layout() {
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-2 h-4" />
             <span className="text-sm text-muted-foreground">
-              {NAV_ITEMS.find((n) => isActive(n.to))?.label ?? (isActive('/admin') ? 'Admin' : isActive('/cost') ? 'Cost' : isActive('/audit') ? 'Audit Log' : '')}
+              {NAV_ITEMS.find((n) => isActive(n.to))?.label ?? (isActive('/admin') ? 'Admin' : isActive('/cost') ? 'Cost' : isActive('/kpis') ? 'Product Health' : isActive('/audit') ? 'Audit Log' : '')}
             </span>
           </header>
           <main className="flex-1 p-6 page-enter" key={location.pathname}>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -382,6 +382,26 @@ export const getAuditLog = (params?: AuditLogParams) => {
   return apiFetch<PaginatedAuditLog>(`/api/admin/audit-log${qs ? `?${qs}` : ''}`);
 };
 
+// Product health KPIs (issue #73)
+export interface KpiTrendPoint {
+  day: string;
+  sessions: number;
+  tasks_with_pr: number;
+}
+export interface Kpis {
+  window_days: number;
+  weekly_active_prompting_users: number;
+  sessions: number;
+  tasks_with_pr: number;
+  session_to_pr_conversion_rate: number;
+  median_time_to_first_pr_seconds: number | null;
+  trends: KpiTrendPoint[];
+}
+export const getKpis = (days?: number) => {
+  const qs = days ? `?days=${days}` : '';
+  return apiFetch<Kpis>(`/api/admin/metrics/kpis${qs}`);
+};
+
 // AI Settings
 export const getAiSettings = () =>
   apiFetch<{ provider: string | null; has_api_key: boolean; model: string | null; has_global_fallback?: boolean }>('/api/settings/ai');

--- a/dashboard/frontend/src/pages/KPIDashboard.tsx
+++ b/dashboard/frontend/src/pages/KPIDashboard.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Navigate } from 'react-router-dom';
+import { getMe, getKpis } from '@/lib/api';
+import type { KpiTrendPoint } from '@/lib/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Users, GitPullRequest, Gauge, Clock, BarChart3 } from 'lucide-react';
+
+const PERIOD_OPTIONS = [
+  { value: '7', label: 'Last 7 days' },
+  { value: '30', label: 'Last 30 days' },
+  { value: '90', label: 'Last 90 days' },
+] as const;
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  if (mins < 60) return `${mins}m ${secs}s`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ${mins % 60}m`;
+}
+
+export default function KPIDashboard() {
+  const { data: me } = useQuery({ queryKey: ['me'], queryFn: getMe });
+  const [days, setDays] = useState<number>(30);
+
+  if (me && me.role !== 'admin') {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Product Health</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Adoption and impact KPIs. Merge-status tracking is a follow-up; "PR"
+            currently means a reviewable PR has been opened from the task.
+          </p>
+        </div>
+        <Select value={String(days)} onValueChange={(v) => setDays(Number(v))}>
+          <SelectTrigger className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PERIOD_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <KpiCards days={days} />
+      <TrendChart days={days} />
+    </div>
+  );
+}
+
+function KpiCards({ days }: { days: number }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['kpis', days],
+    queryFn: () => getKpis(days),
+  });
+
+  const conversionPct =
+    data != null ? `${(data.session_to_pr_conversion_rate * 100).toFixed(1)}%` : '-';
+  const median =
+    data?.median_time_to_first_pr_seconds != null
+      ? formatDuration(data.median_time_to_first_pr_seconds)
+      : data
+      ? 'n/a'
+      : '-';
+
+  const cards = [
+    {
+      title: 'Weekly Active Prompting Users',
+      value: data ? String(data.weekly_active_prompting_users) : '-',
+      hint: 'Distinct users who created a task in the last 7 days',
+      icon: Users,
+    },
+    {
+      title: 'Session → PR Conversion',
+      value: conversionPct,
+      hint: data
+        ? `${data.tasks_with_pr} of ${data.sessions} tasks opened a PR`
+        : `Share of tasks that opened a PR in the last ${days} days`,
+      icon: GitPullRequest,
+    },
+    {
+      title: 'Median Time to First PR',
+      value: median,
+      hint: 'Task creation → task.pr_created audit event',
+      icon: Clock,
+    },
+    {
+      title: 'Sessions',
+      value: data ? String(data.sessions) : '-',
+      hint: `Tasks created in the last ${days} days`,
+      icon: Gauge,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map((c) => (
+        <Card key={c.title}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {c.title}
+            </CardTitle>
+            <c.icon className="size-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <p className="text-muted-foreground text-sm">Loading...</p>
+            ) : (
+              <>
+                <p className="text-2xl font-bold tabular-nums">{c.value}</p>
+                <p className="text-xs text-muted-foreground mt-1">{c.hint}</p>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function TrendChart({ days }: { days: number }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['kpis', days],
+    queryFn: () => getKpis(days),
+  });
+
+  const trends: KpiTrendPoint[] = data?.trends ?? [];
+
+  const rawMax = trends.length ? Math.max(...trends.map((t) => t.sessions), 1) : 1;
+  function niceMax(v: number): number {
+    if (v <= 0) return 1;
+    const mag = Math.pow(10, Math.floor(Math.log10(v)));
+    const norm = v / mag;
+    if (norm <= 1) return mag;
+    if (norm <= 2) return 2 * mag;
+    if (norm <= 5) return 5 * mag;
+    return 10 * mag;
+  }
+  const maxY = niceMax(rawMax);
+
+  const width = 800;
+  const height = 200;
+  const padLeft = 48;
+  const padRight = 20;
+  const padTop = 10;
+  const padBottom = 30;
+  const chartW = width - padLeft - padRight;
+  const chartH = height - padTop - padBottom;
+
+  const xFor = (i: number) =>
+    padLeft + (trends.length === 1 ? chartW / 2 : (i / (trends.length - 1)) * chartW);
+  const yFor = (v: number) => padTop + chartH - (v / maxY) * chartH;
+
+  const sessionPts = trends.map((t, i) => ({ x: xFor(i), y: yFor(t.sessions), t }));
+  const prPts = trends.map((t, i) => ({ x: xFor(i), y: yFor(t.tasks_with_pr), t }));
+
+  const toPath = (pts: { x: number; y: number }[]) =>
+    pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+
+  const yTicks = [0, maxY / 2, maxY];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <BarChart3 className="size-5" />
+          Sessions & PRs per Day
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p className="text-muted-foreground text-sm">Loading chart...</p>
+        ) : !trends.length ? (
+          <p className="text-muted-foreground text-sm">No data for this period.</p>
+        ) : (
+          <>
+            <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-48">
+              {yTicks.map((v) => {
+                const y = yFor(v);
+                return (
+                  <g key={v}>
+                    <line
+                      x1={padLeft}
+                      y1={y}
+                      x2={width - padRight}
+                      y2={y}
+                      stroke="currentColor"
+                      strokeOpacity={0.15}
+                    />
+                    <text
+                      x={padLeft - 8}
+                      y={y + 4}
+                      textAnchor="end"
+                      className="fill-muted-foreground"
+                      style={{ fontSize: 11 }}
+                    >
+                      {Math.round(v)}
+                    </text>
+                  </g>
+                );
+              })}
+
+              <path
+                d={toPath(sessionPts)}
+                fill="none"
+                className="stroke-primary"
+                strokeWidth={2}
+                strokeLinejoin="round"
+              />
+              <path
+                d={toPath(prPts)}
+                fill="none"
+                className="stroke-emerald-500"
+                strokeWidth={2}
+                strokeLinejoin="round"
+                strokeDasharray="4 3"
+              />
+
+              {sessionPts.map((p) => {
+                const date = new Date(p.t.day);
+                const label = `${date.getMonth() + 1}/${date.getDate()}`;
+                return (
+                  <g key={`s-${p.t.day}`}>
+                    <circle cx={p.x} cy={p.y} r={3} className="fill-primary" />
+                    <title>{`${label}: ${p.t.sessions} sessions, ${p.t.tasks_with_pr} PRs`}</title>
+                    {trends.length <= 31 && (
+                      <text
+                        x={p.x}
+                        y={padTop + chartH + 16}
+                        textAnchor="middle"
+                        className="fill-muted-foreground"
+                        style={{ fontSize: 9 }}
+                      >
+                        {label}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+              {prPts.map((p) => (
+                <circle
+                  key={`p-${p.t.day}`}
+                  cx={p.x}
+                  cy={p.y}
+                  r={3}
+                  className="fill-emerald-500"
+                />
+              ))}
+            </svg>
+            <div className="flex gap-4 mt-3 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-block h-0.5 w-4 bg-primary" />
+                Sessions
+              </span>
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-block h-0.5 w-4 bg-emerald-500" />
+                Tasks with PR
+              </span>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an admin-only **Product Health** page at `/kpis` surfacing the adoption and impact KPIs from #73.
- New backend endpoint `GET /api/admin/metrics/kpis?days={n}` computes everything from the local DB — no live GitHub API calls on the metrics path.

## KPIs shipped
- **Weekly active prompting users** — distinct `created_by` on `tasks` in the last 7 days.
- **Session → PR conversion** — share of tasks in the selected window where `pr_url IS NOT NULL`.
- **Median time-to-first-reviewable-PR** — median seconds from `tasks.created_at` to the first `task.pr_created` event in `audit_log` for that task.
- **Daily trend chart** — sessions vs tasks with PRs per day.

## Deferred (follow-up)
The issue asks for *merged*-PR conversion specifically. The local DB has no merge signal today, so this PR lands the infrastructure using **reviewable PR** (opened) as the proxy, and calls it out in the UI. Merge tracking needs either a PR webhook or a background sync job; both are bigger than this change.

## Test plan
- [ ] `cargo check` / `cargo clippy` on `dashboard/backend` (clean).
- [ ] `npm run build` on `dashboard/frontend` (clean; pre-existing lint warnings only).
- [ ] As an admin, `/kpis` renders four KPI cards plus the daily trend chart.
- [ ] Non-admin user visiting `/kpis` is redirected to `/`.
- [ ] Non-admin hitting `/api/admin/metrics/kpis` gets 401.
- [ ] Period selector (7/30/90) re-queries and updates cards + chart.
- [ ] With zero data in the window, cards show `0` / `0.0%` / `n/a` and the chart shows the empty-state message.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)